### PR TITLE
feat: add enum for symfony data collectors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:v2
+          tools: composer:v2, phpstan
           extensions: ctype, iconv, intl, json, mbstring, pdo, pdo_sqlite
           coverage: none
 
@@ -56,39 +56,38 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json', 'composer.lock') }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.{json,lock}') }}
           restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-
 
       - name: Install PHPUnit 10
-        run: composer require --dev --no-update "phpunit/phpunit=^10.0"
+        run: composer require --dev --no-update phpunit/phpunit:^10.0
 
       - name: Install dependencies
         env:
           MATRIX_SYMFONY: ${{ matrix.symfony }}
         run: |
-          composer require symfony/finder=${{ env.COMP_SYMFONY }} --no-update
-          composer require symfony/yaml=${{ env.COMP_SYMFONY }} --no-update
-          composer require symfony/console=${{ env.COMP_SYMFONY }} --no-update
-          composer require symfony/event-dispatcher=${{ env.COMP_SYMFONY }} --no-update
-          composer require symfony/css-selector=${{ env.COMP_SYMFONY }} --no-update
-          composer require symfony/dom-crawler=${{ env.COMP_SYMFONY }} --no-update
-          composer require symfony/browser-kit=${{ env.COMP_SYMFONY }} --no-update
-          composer require vlucas/phpdotenv --no-update
-          composer require codeception/module-asserts="3.*" --no-update
-          composer require codeception/module-doctrine="3.*" --no-update
+          composer require --no-update \
+            symfony/{finder,yaml,console,event-dispatcher,css-selector,dom-crawler,browser-kit}:${{ env.COMP_SYMFONY }} \
+            vlucas/phpdotenv \
+            codeception/module-asserts:"3.*" \
+            codeception/module-doctrine:"3.*"
 
           if [[ "$MATRIX_SYMFONY" == "6.4wApi" ]]; then
             composer require codeception/module-rest="3.*" --no-update
           fi
 
-          composer update --prefer-dist --no-progress --no-dev
+          composer update --prefer-dist --no-progress
+
+      - name: Run PHPStan (max)
+        if: ${{ matrix.symfony == '7.2.*' }}
+        run: phpstan analyse src --level=max --no-progress --error-format=github --memory-limit=1G
 
       - name: Validate Composer files
         run: composer validate --strict
         working-directory: framework-tests
 
       - name: Install PHPUnit in framework-tests
-        run: composer require --dev --no-update "phpunit/phpunit=^10.0"
+        run: composer require --dev --no-update phpunit/phpunit:^10.0
         working-directory: framework-tests
 
       - name: Prepare Symfony sample

--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -5,44 +5,46 @@ declare(strict_types=1);
 namespace Codeception\Lib\Connector;
 
 use InvalidArgumentException;
-use ReflectionClass;
+use LogicException;
 use ReflectionMethod;
 use ReflectionProperty;
 use Symfony\Bundle\FrameworkBundle\Test\TestContainer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
-use function array_keys;
+
 use function codecept_debug;
 
+/**
+ * @property KernelInterface $kernel
+ */
 class Symfony extends HttpKernelBrowser
 {
+    private ContainerInterface $container;
     private bool $hasPerformedRequest = false;
-    private ?ContainerInterface $container;
 
+    /**
+     * @param Kernel $kernel
+     * @param array<string, object> $persistentServices
+     */
     public function __construct(
-        Kernel $kernel,
+        $kernel,
         public array $persistentServices = [],
-        private readonly bool $rebootable = true
+        private bool $reboot = true
     ) {
         parent::__construct($kernel);
         $this->followRedirects();
-        $this->container = $this->getContainer();
+        $this->container = $this->resolveContainer();
         $this->rebootKernel();
     }
 
-    /** @param Request $request */
     protected function doRequest(object $request): Response
     {
-        if ($this->rebootable) {
-            if ($this->hasPerformedRequest) {
-                $this->rebootKernel();
-            } else {
-                $this->hasPerformedRequest = true;
-            }
+        if ($this->reboot) {
+            $this->hasPerformedRequest ? $this->rebootKernel() : $this->hasPerformedRequest = true;
         }
 
         return parent::doRequest($request);
@@ -57,30 +59,27 @@ class Symfony extends HttpKernelBrowser
      */
     public function rebootKernel(): void
     {
-        if ($this->container) {
-            foreach (array_keys($this->persistentServices) as $serviceName) {
-                if ($service = $this->getService($serviceName)) {
-                    $this->persistentServices[$serviceName] = $service;
-                }
+        foreach (array_keys($this->persistentServices) as $service) {
+            if ($this->container->has($service)) {
+                $this->persistentServices[$service] = $this->container->get($service);
             }
         }
 
         $this->persistDoctrineConnections();
-        $this->ensureKernelShutdown();
-        $this->kernel->boot();
-        $this->container = $this->getContainer();
-
-        foreach ($this->persistentServices as $serviceName => $service) {
+        if ($this->kernel instanceof Kernel) {
+            $this->ensureKernelShutdown();
+            $this->kernel->boot();
+        }
+        $this->container = $this->resolveContainer();
+        foreach ($this->persistentServices as $name => $service) {
             try {
-                $this->container->set($serviceName, $service);
+                $this->container->set($name, $service);
             } catch (InvalidArgumentException $e) {
-                codecept_debug("[Symfony] Can't set persistent service {$serviceName}: " . $e->getMessage());
+                codecept_debug("[Symfony] Can't set persistent service {$name}: {$e->getMessage()}");
             }
         }
 
-        if ($profiler = $this->getProfiler()) {
-            $profiler->enable();
-        }
+        $this->getProfiler()?->enable();
     }
 
     protected function ensureKernelShutdown(): void
@@ -89,27 +88,25 @@ class Symfony extends HttpKernelBrowser
         $this->kernel->shutdown();
     }
 
-    private function getContainer(): ?ContainerInterface
+    private function resolveContainer(): ContainerInterface
     {
-        /** @var ContainerInterface $container */
         $container = $this->kernel->getContainer();
-        return $container->has('test.service_container')
-            ? $container->get('test.service_container')
-            : $container;
+
+        if ($container->has('test.service_container')) {
+            $testContainer = $container->get('test.service_container');
+            if (!$testContainer instanceof ContainerInterface) {
+                throw new LogicException('Service "test.service_container" must implement ' . ContainerInterface::class);
+            }
+            $container = $testContainer;
+        }
+
+        return $container;
     }
 
     private function getProfiler(): ?Profiler
     {
-        return $this->container->has('profiler')
-            ? $this->container->get('profiler')
-            : null;
-    }
-
-    private function getService(string $serviceName): ?object
-    {
-        return $this->container->has($serviceName)
-            ? $this->container->get($serviceName)
-            : null;
+        $profiler = $this->container->get('profiler');
+        return $profiler instanceof Profiler ? $profiler : null;
     }
 
     private function persistDoctrineConnections(): void
@@ -119,20 +116,27 @@ class Symfony extends HttpKernelBrowser
         }
 
         if ($this->container instanceof TestContainer) {
-            $reflectedTestContainer = new ReflectionMethod($this->container, 'getPublicContainer');
-            $reflectedTestContainer->setAccessible(true);
-            $publicContainer = $reflectedTestContainer->invoke($this->container);
+            $method = new ReflectionMethod($this->container, 'getPublicContainer');
+            $publicContainer = $method->invoke($this->container);
         } else {
             $publicContainer = $this->container;
         }
 
-        $reflectedContainer = new ReflectionClass($publicContainer);
-        $reflectionTarget = $reflectedContainer->hasProperty('parameters') ? $publicContainer : $publicContainer->getParameterBag();
+        if (!is_object($publicContainer) || !method_exists($publicContainer, 'getParameterBag')) {
+            return;
+        }
 
-        $reflectedParameters = new ReflectionProperty($reflectionTarget, 'parameters');
-        $reflectedParameters->setAccessible(true);
-        $parameters = $reflectedParameters->getValue($reflectionTarget);
-        unset($parameters['doctrine.connections']);
-        $reflectedParameters->setValue($reflectionTarget, $parameters);
+        $target = property_exists($publicContainer, 'parameters')
+            ? $publicContainer
+            : $publicContainer->getParameterBag();
+
+        if (!is_object($target) || !property_exists($target, 'parameters')) {
+            return;
+        }
+        $prop = new ReflectionProperty($target, 'parameters');
+
+        $params = (array) $prop->getValue($target);
+        unset($params['doctrine.connections']);
+        $prop->setValue($target, $params);
     }
 }

--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -5,44 +5,44 @@ declare(strict_types=1);
 namespace Codeception\Lib\Connector;
 
 use InvalidArgumentException;
-use ReflectionClass;
+use LogicException;
 use ReflectionMethod;
 use ReflectionProperty;
 use Symfony\Bundle\FrameworkBundle\Test\TestContainer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
-use function array_keys;
+
 use function codecept_debug;
 
+/**
+ * @property KernelInterface $kernel
+ */
 class Symfony extends HttpKernelBrowser
 {
+    private ContainerInterface $container;
     private bool $hasPerformedRequest = false;
-    private ?ContainerInterface $container;
 
     public function __construct(
-        Kernel $kernel,
+        HttpKernelInterface $kernel,
+        /** @var array<string, object> */
         public array $persistentServices = [],
-        private readonly bool $rebootable = true
+        private bool $reboot = true
     ) {
         parent::__construct($kernel);
         $this->followRedirects();
-        $this->container = $this->getContainer();
+        $this->container = $this->resolveContainer();
         $this->rebootKernel();
     }
 
-    /** @param Request $request */
     protected function doRequest(object $request): Response
     {
-        if ($this->rebootable) {
-            if ($this->hasPerformedRequest) {
-                $this->rebootKernel();
-            } else {
-                $this->hasPerformedRequest = true;
-            }
+        if ($this->reboot) {
+            $this->hasPerformedRequest ? $this->rebootKernel() : $this->hasPerformedRequest = true;
         }
 
         return parent::doRequest($request);
@@ -57,30 +57,27 @@ class Symfony extends HttpKernelBrowser
      */
     public function rebootKernel(): void
     {
-        if ($this->container) {
-            foreach (array_keys($this->persistentServices) as $serviceName) {
-                if ($service = $this->getService($serviceName)) {
-                    $this->persistentServices[$serviceName] = $service;
-                }
+        foreach (array_keys($this->persistentServices) as $service) {
+            if ($this->container->has($service)) {
+                $this->persistentServices[$service] = $this->container->get($service);
             }
         }
 
         $this->persistDoctrineConnections();
-        $this->ensureKernelShutdown();
-        $this->kernel->boot();
-        $this->container = $this->getContainer();
-
-        foreach ($this->persistentServices as $serviceName => $service) {
+        if ($this->kernel instanceof Kernel) {
+            $this->ensureKernelShutdown();
+            $this->kernel->boot();
+        }
+        $this->container = $this->resolveContainer();
+        foreach ($this->persistentServices as $name => $service) {
             try {
-                $this->container->set($serviceName, $service);
+                $this->container->set($name, $service);
             } catch (InvalidArgumentException $e) {
-                codecept_debug("[Symfony] Can't set persistent service {$serviceName}: " . $e->getMessage());
+                codecept_debug("[Symfony] Can't set persistent service {$name}: {$e->getMessage()}");
             }
         }
 
-        if ($profiler = $this->getProfiler()) {
-            $profiler->enable();
-        }
+        $this->getProfiler()?->enable();
     }
 
     protected function ensureKernelShutdown(): void
@@ -89,27 +86,25 @@ class Symfony extends HttpKernelBrowser
         $this->kernel->shutdown();
     }
 
-    private function getContainer(): ?ContainerInterface
+    private function resolveContainer(): ContainerInterface
     {
-        /** @var ContainerInterface $container */
         $container = $this->kernel->getContainer();
-        return $container->has('test.service_container')
-            ? $container->get('test.service_container')
-            : $container;
+
+        if ($container->has('test.service_container')) {
+            $testContainer = $container->get('test.service_container');
+            if (!$testContainer instanceof ContainerInterface) {
+                throw new LogicException('Service "test.service_container" must implement ' . ContainerInterface::class);
+            }
+            $container = $testContainer;
+        }
+
+        return $container;
     }
 
     private function getProfiler(): ?Profiler
     {
-        return $this->container->has('profiler')
-            ? $this->container->get('profiler')
-            : null;
-    }
-
-    private function getService(string $serviceName): ?object
-    {
-        return $this->container->has($serviceName)
-            ? $this->container->get($serviceName)
-            : null;
+        $profiler = $this->container->get('profiler');
+        return $profiler instanceof Profiler ? $profiler : null;
     }
 
     private function persistDoctrineConnections(): void
@@ -119,20 +114,27 @@ class Symfony extends HttpKernelBrowser
         }
 
         if ($this->container instanceof TestContainer) {
-            $reflectedTestContainer = new ReflectionMethod($this->container, 'getPublicContainer');
-            $reflectedTestContainer->setAccessible(true);
-            $publicContainer = $reflectedTestContainer->invoke($this->container);
+            $method = new ReflectionMethod($this->container, 'getPublicContainer');
+            $publicContainer = $method->invoke($this->container);
         } else {
             $publicContainer = $this->container;
         }
 
-        $reflectedContainer = new ReflectionClass($publicContainer);
-        $reflectionTarget = $reflectedContainer->hasProperty('parameters') ? $publicContainer : $publicContainer->getParameterBag();
+        if (!is_object($publicContainer) || !method_exists($publicContainer, 'getParameterBag')) {
+            return;
+        }
 
-        $reflectedParameters = new ReflectionProperty($reflectionTarget, 'parameters');
-        $reflectedParameters->setAccessible(true);
-        $parameters = $reflectedParameters->getValue($reflectionTarget);
-        unset($parameters['doctrine.connections']);
-        $reflectedParameters->setValue($reflectionTarget, $parameters);
+        $target = property_exists($publicContainer, 'parameters')
+            ? $publicContainer
+            : $publicContainer->getParameterBag();
+
+        if (!is_object($target) || !property_exists($target, 'parameters')) {
+            return;
+        }
+        $prop = new ReflectionProperty($target, 'parameters');
+
+        $params = (array) $prop->getValue($target);
+        unset($params['doctrine.connections']);
+        $prop->setValue($target, $params);
     }
 }

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -32,31 +32,40 @@ use Codeception\Module\Symfony\ValidatorAssertionsTrait;
 use Codeception\TestInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
-use LogicException;
+use PHPUnit\Framework\Assert;
 use ReflectionClass;
 use ReflectionException;
+use Symfony\Bridge\Twig\DataCollector\TwigDataCollector;
 use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Form\Extension\DataCollector\FormDataCollector;
+use Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
+use Symfony\Component\Translation\DataCollector\TranslationDataCollector;
 use Symfony\Component\VarDumper\Cloner\Data;
 use function array_keys;
 use function array_map;
 use function array_unique;
+use function array_values;
 use function class_exists;
 use function codecept_root_dir;
 use function count;
 use function file_exists;
 use function implode;
+use function in_array;
 use function ini_get;
 use function ini_set;
+use function is_object;
 use function iterator_to_array;
 use function number_format;
 use function sprintf;
@@ -132,7 +141,6 @@ use function sprintf;
  *
  * If you're using Symfony with Eloquent ORM (instead of Doctrine), you can load the [`ORM` part of Laravel module](https://codeception.com/docs/modules/Laravel#Parts)
  * in addition to Symfony module.
- *
  */
 class Symfony extends Framework implements DoctrineProvider, PartedModule
 {
@@ -158,40 +166,54 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
     public Kernel $kernel;
 
-    /**
-     * @var SymfonyConnector
-     */
+    /** @var SymfonyConnector|null */
     public ?AbstractBrowser $client = null;
 
     /**
-     * @var array<string, mixed>
+     * @var array{
+     *     app_path:string,
+     *     kernel_class:string,
+     *     environment:string,
+     *     debug:bool,
+     *     cache_router:bool,
+     *     em_service:string,
+     *     rebootable_client:bool,
+     *     authenticator:bool,
+     *     bootstrap:bool,
+     *     guard:bool
+     * }
      */
     public array $config = [
-        'app_path' => 'app',
-        'kernel_class' => 'App\Kernel',
-        'environment' => 'test',
-        'debug' => true,
-        'cache_router' => false,
-        'em_service' => 'doctrine.orm.entity_manager',
+        'app_path'          => 'app',
+        'kernel_class'      => 'App\\Kernel',
+        'environment'       => 'test',
+        'debug'             => true,
+        'cache_router'      => false,
+        'em_service'        => 'doctrine.orm.entity_manager',
         'rebootable_client' => true,
-        'authenticator' => false,
-        'bootstrap' => false,
-        'guard' => false
+        'authenticator'     => false,
+        'bootstrap'         => false,
+        'guard'             => false,
     ];
 
+    /** @var class-string<Kernel>|null */
     protected ?string $kernelClass = null;
+
     /**
      * Services that should be persistent permanently for all tests
+     *
+     * @var array<string, object>
      */
     protected array $permanentServices = [];
+
     /**
      * Services that should be persistent during test execution between kernel reboots
+     *
+     * @var array<string, object>
      */
     protected array $persistentServices = [];
 
-    /**
-     * @return string[]
-     */
+    /** @return list<string> */
     public function _parts(): array
     {
         return ['services'];
@@ -201,36 +223,56 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     {
         $this->kernelClass = $this->getKernelClass();
         $this->setXdebugMaxNestingLevel(200);
-        $this->kernel = new $this->kernelClass($this->config['environment'], $this->config['debug']);
+
+        /** @var class-string<Kernel> $kernelClass */
+        $kernelClass = $this->kernelClass;
+        $this->kernel = new $kernelClass(
+            $this->config['environment'],
+            $this->config['debug']
+        );
+
         if ($this->config['bootstrap']) {
             $this->bootstrapEnvironment();
         }
+
         $this->kernel->boot();
+
         if ($this->config['cache_router']) {
             $this->persistPermanentService('router');
         }
     }
 
     /**
-     * Initialize new client instance before each test
+     * Initialize new client instance before each test.
      */
     public function _before(TestInterface $test): void
     {
         $this->persistentServices = array_merge($this->persistentServices, $this->permanentServices);
-        $this->client = new SymfonyConnector($this->kernel, $this->persistentServices, $this->config['rebootable_client']);
+
+        $this->client = new SymfonyConnector(
+            $this->kernel,
+            $this->persistentServices,
+            $this->config['rebootable_client']
+        );
     }
 
     /**
-     * Update permanent services after each test
+     * Update permanent services after each test.
      */
     public function _after(TestInterface $test): void
     {
         foreach (array_keys($this->permanentServices) as $serviceName) {
-            $this->permanentServices[$serviceName] = $this->grabService($serviceName);
+            $service = $this->getService($serviceName);
+            if (is_object($service)) {
+                $this->permanentServices[$serviceName] = $service;
+            } else {
+                unset($this->permanentServices[$serviceName]);
+            }
         }
         parent::_after($test);
     }
 
+    /** @param array<string, string|bool> $settings */
     protected function onReconfigure(array $settings = []): void
     {
         parent::_beforeSuite($settings);
@@ -238,213 +280,259 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
-     * Retrieve Entity Manager.
-     *
-     * EM service is retrieved once and then that instance returned on each call
+     * Retrieve the Doctrine EntityManager.
+     * EntityManager service is retrieved once and then reused.
      */
     public function _getEntityManager(): EntityManagerInterface
     {
-        if ($this->kernel === null) {
-            $this->fail('Symfony module is not loaded');
-        }
-
         $emService = $this->config['em_service'];
+
         if (!isset($this->permanentServices[$emService])) {
             $this->persistPermanentService($emService);
             $container = $this->_getContainer();
-            $services = ['doctrine', 'doctrine.orm.default_entity_manager', 'doctrine.dbal.default_connection'];
-            foreach ($services as $service) {
+            foreach (
+                ['doctrine', 'doctrine.orm.default_entity_manager', 'doctrine.dbal.default_connection']
+                as $service
+            ) {
                 if ($container->has($service)) {
                     $this->persistPermanentService($service);
                 }
             }
         }
 
+        /** @var EntityManagerInterface */
         return $this->permanentServices[$emService];
     }
 
     public function _getContainer(): ContainerInterface
     {
         $container = $this->kernel->getContainer();
-
-        return $container->has('test.service_container') ? $container->get('test.service_container') : $container;
+        /** @var ContainerInterface $testContainer */
+        $testContainer = $container->has('test.service_container') ? $container->get('test.service_container') : $container;
+        return $testContainer;
     }
 
     protected function getClient(): SymfonyConnector
     {
-        return $this->client ?: $this->fail('Client is not initialized');
+        if ($this->client === null) {
+            Assert::fail('Client is not initialized');
+        }
+
+        return $this->client;
     }
 
     /**
-     * Attempts to guess the kernel location.
-     * When the Kernel is located, the file is required.
+     * Find and require the Kernel class file.
      *
-     * @return string The Kernel class name
+     * @return class-string<Kernel>
      * @throws ModuleRequireException|ReflectionException
      */
     protected function getKernelClass(): string
     {
-        $path = codecept_root_dir() . $this->config['app_path'];
+        /** @var string $rootDir */
+        $rootDir = codecept_root_dir();
+        $path    = $rootDir . $this->config['app_path'];
+
         if (!file_exists($path)) {
             throw new ModuleRequireException(
                 self::class,
-                "Can't load Kernel from {$path}.\n"
-                . 'Directory does not exist. Set `app_path` in your suite configuration to a valid application path.'
+                "Can't load Kernel from {$path}.\n" .
+                'Directory does not exist. Set `app_path` in your suite configuration to a valid application path.'
             );
         }
 
         $this->requireAdditionalAutoloader();
 
-        $finder = new Finder();
+        $finder  = new Finder();
         $results = iterator_to_array($finder->name('*Kernel.php')->depth('0')->in($path));
+
         if ($results === []) {
             throw new ModuleRequireException(
                 self::class,
-                "File with Kernel class was not found at {$path}.\n"
-                . 'Specify directory where file with Kernel class for your application is located with `app_path` parameter.'
+                "File with Kernel class was not found at {$path}.\n" .
+                'Specify directory where file with Kernel class for your application is located with `app_path` parameter.'
             );
         }
 
-        $kernelClass = $this->config['kernel_class'];
-        $filesRealPath = array_map(static function ($file) {
-            require_once $file;
-            return $file->getRealPath();
-        }, $results);
+        $kernelClass   = $this->config['kernel_class'];
+        $filesRealPath = [];
+
+        foreach ($results as $file) {
+            include_once $file->getRealPath();
+            $filesRealPath[] = $file->getRealPath();
+        }
 
         if (class_exists($kernelClass)) {
-            $reflectionClass = new ReflectionClass($kernelClass);
-            if (in_array($reflectionClass->getFileName(), $filesRealPath, true)) {
+            $ref      = new ReflectionClass($kernelClass);
+            $fileName = $ref->getFileName();
+            if ($fileName !== false && in_array($fileName, $filesRealPath, true)) {
+                /** @var class-string<Kernel> $kernelClass */
                 return $kernelClass;
             }
         }
 
         throw new ModuleRequireException(
             self::class,
-            "Kernel class was not found.\n"
-            . 'Specify directory where file with Kernel class for your application is located with `kernel_class` parameter.'
+            "Kernel class was not found.\n" .
+            'Specify directory where file with Kernel class for your application is located with `kernel_class` parameter.'
         );
     }
 
     protected function getProfile(): ?Profile
     {
-        /** @var Profiler $profiler */
+        /** @var Profiler|null $profiler */
         $profiler = $this->getService('profiler');
-        try {
-            return $profiler?->loadProfileFromResponse($this->getClient()->getResponse());
-        } catch (BadMethodCallException) {
-            $this->fail('You must perform a request before using this method.');
-        } catch (Exception $e) {
-            $this->fail($e->getMessage());
+
+        if ($profiler === null) {
+            return null;
         }
 
-        return null;
+        try {
+            return $profiler->loadProfileFromResponse($this->getClient()->getResponse());
+        } catch (BadMethodCallException) {
+            Assert::fail('You must perform a request before using this method.');
+        } catch (Exception $e) {
+            Assert::fail($e->getMessage());
+        }
     }
 
     /**
-     * Grabs a Symfony Data Collector
+     * Grab a Symfony Data Collector from the current profile.
+     *
+     * @return EventDataCollector|FormDataCollector|HttpClientDataCollector|LoggerDataCollector|TimeDataCollector|TranslationDataCollector|TwigDataCollector|DataCollectorInterface|SecurityDataCollector|MessageDataCollector
+     *
+     * @phpstan-return (
+     *     $collector is 'events' ? EventDataCollector :
+     *     ($collector is 'form' ? FormDataCollector :
+     *     ($collector is 'http_client' ? HttpClientDataCollector :
+     *     ($collector is 'logger' ? LoggerDataCollector :
+     *     ($collector is 'time' ? TimeDataCollector :
+     *     ($collector is 'translation' ? TranslationDataCollector :
+     *     ($collector is 'twig' ? TwigDataCollector :
+     *     ($collector is 'security' ? SecurityDataCollector :
+     *     ($collector is 'mailer' ? MessageDataCollector :
+     *      DataCollectorInterface
+     *     ))))))))
+     * )
      */
     protected function grabCollector(string $collector, string $function, ?string $message = null): DataCollectorInterface
     {
         $profile = $this->getProfile();
+
         if ($profile === null) {
-            $this->fail(sprintf("The Profile is needed to use the '%s' function.", $function));
+            Assert::fail(sprintf("The Profile is needed to use the '%s' function.", $function));
         }
+
         if (!$profile->hasCollector($collector)) {
-            $this->fail($message ?: "The '{$collector}' collector is needed to use the '{$function}' function.");
+            Assert::fail($message ?: "The '{$collector}' collector is needed to use the '{$function}' function.");
         }
 
         return $profile->getCollector($collector);
     }
 
     /**
-     * Set the data that will be displayed when running a test with the `--debug` flag
-     *
-     * @param mixed $url
+     * Set the data that will be displayed when running a test with the `--debug` flag.
      */
-    protected function debugResponse($url): void
+    protected function debugResponse(mixed $url): void
     {
         parent::debugResponse($url);
-        if ($profile = $this->getProfile()) {
-            $collectors = [
-                'security' => 'debugSecurityData',
-                'mailer'   => 'debugMailerData',
-                'time'     => 'debugTimeData',
-            ];
-            foreach ($collectors as $collector => $method) {
-                if ($profile->hasCollector($collector)) {
-                    $this->$method($profile->getCollector($collector));
+
+        $profile = $this->getProfile();
+        if ($profile === null) {
+            return;
+        }
+
+        if ($profile->hasCollector('security')) {
+            $securityCollector = $profile->getCollector('security');
+            if ($securityCollector instanceof SecurityDataCollector) {
+                $this->debugSecurityData($securityCollector);
+            }
+        }
+
+        if ($profile->hasCollector('mailer')) {
+            $mailerCollector = $profile->getCollector('mailer');
+            if ($mailerCollector instanceof MessageDataCollector) {
+                $this->debugMailerData($mailerCollector);
+            }
+        }
+
+        if ($profile->hasCollector('time')) {
+            $timeCollector = $profile->getCollector('time');
+            if ($timeCollector instanceof TimeDataCollector) {
+                $this->debugTimeData($timeCollector);
+            }
+        }
+    }
+
+    /** @return list<non-empty-string> */
+    protected function getInternalDomains(): array
+    {
+        $domains = [];
+
+        foreach ($this->grabRouterService()->getRouteCollection() as $route) {
+            if ($route->getHost() !== '') {
+                $regex = $route->compile()->getHostRegex();
+                if ($regex !== null && $regex !== '') {
+                    $domains[] = $regex;
                 }
             }
+        }
+
+        /** @var list<non-empty-string> */
+        return array_values(array_unique($domains));
+    }
+
+    /**
+     * Ensure Xdebug allows deep nesting.
+     */
+    private function setXdebugMaxNestingLevel(int $max): void
+    {
+        if ((int) ini_get('xdebug.max_nesting_level') < $max) {
+            ini_set('xdebug.max_nesting_level', (string) $max);
         }
     }
 
     /**
-     * Returns a list of recognized domain names.
+     * Bootstrap environment via tests/bootstrap.php or Dotenv.
      */
-    protected function getInternalDomains(): array
-    {
-        $internalDomains = [];
-        $router = $this->grabRouterService();
-        $routes = $router->getRouteCollection();
-
-        foreach ($routes as $route) {
-            if ($route->getHost() !== null) {
-                $compiledRoute = $route->compile();
-                if ($compiledRoute->getHostRegex() !== null) {
-                    $internalDomains[] = $compiledRoute->getHostRegex();
-                }
-            }
-        }
-
-        return array_unique($internalDomains);
-    }
-
-    private function setXdebugMaxNestingLevel(int $maxNestingLevel): void
-    {
-        if (ini_get('xdebug.max_nesting_level') < $maxNestingLevel) {
-            ini_set('xdebug.max_nesting_level', (string)$maxNestingLevel);
-        }
-    }
-
     private function bootstrapEnvironment(): void
     {
         $bootstrapFile = $this->kernel->getProjectDir() . '/tests/bootstrap.php';
+
         if (file_exists($bootstrapFile)) {
-            require_once $bootstrapFile;
-        } else {
-            if (!method_exists(Dotenv::class, 'bootEnv')) {
-                throw new LogicException(
-                    "Symfony DotEnv is missing. Try running 'composer require symfony/dotenv'\n" .
-                    "If you can't install DotEnv add your env files to the 'params' key in codeception.yml\n" .
-                    "or update your symfony/framework-bundle recipe by running:\n" .
-                    'composer recipes:install symfony/framework-bundle --force'
-                );
-            }
-            $_ENV['APP_ENV'] = $this->config['environment'];
-            (new Dotenv())->bootEnv('.env');
+            include_once $bootstrapFile;
+            return;
         }
+
+        $_ENV['APP_ENV'] = $this->config['environment'];
+        (new Dotenv())->bootEnv('.env');
     }
 
-    private function debugSecurityData(SecurityDataCollector $security): void
+    private function debugSecurityData(SecurityDataCollector $securityCollector): void
     {
-        if ($security->isAuthenticated()) {
-            $roles = $security->getRoles();
-            $rolesString = implode(',', $roles instanceof Data ? $roles->getValue() : $roles);
-            $userInfo = $security->getUser() . ' [' . $rolesString . ']';
-        } else {
-            $userInfo = 'Anonymous';
+        if (!$securityCollector->isAuthenticated()) {
+            $this->debugSection('User', 'Anonymous');
+            return;
         }
-        $this->debugSection('User', $userInfo);
+
+        $roles = $securityCollector->getRoles();
+        if ($roles instanceof Data) {
+            $roles = $roles->getValue(true);
+        }
+
+        $rolesStr = implode(',', array_map('strval', array_filter((array) $roles, 'is_scalar')));
+        $this->debugSection('User', sprintf('%s [%s]', $securityCollector->getUser(), $rolesStr));
     }
 
-    private function debugMailerData(MessageDataCollector $mailerCollector): void
+    private function debugMailerData(MessageDataCollector $messageCollector): void
     {
-        $this->debugSection('Emails', count($mailerCollector->getEvents()->getMessages()) . ' sent');
+        $count = count($messageCollector->getEvents()->getMessages());
+        $this->debugSection('Emails', sprintf('%d sent', $count));
     }
 
     private function debugTimeData(TimeDataCollector $timeCollector): void
     {
-        $this->debugSection('Time', number_format($timeCollector->getDuration(), 2) . ' ms');
+        $this->debugSection('Time', sprintf('%.2f ms', number_format($timeCollector->getDuration(), 2)));
     }
 
     /**
@@ -453,9 +541,12 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     private function requireAdditionalAutoloader(): void
     {
-        $autoLoader = codecept_root_dir() . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
-        if (file_exists($autoLoader)) {
-            require_once $autoLoader;
+        /** @var string $rootDir */
+        $rootDir  = codecept_root_dir();
+        $autoload = $rootDir . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+        if (file_exists($autoload)) {
+            include_once $autoload;
         }
     }
 }

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -31,7 +31,8 @@ use Codeception\Module\Symfony\TwigAssertionsTrait;
 use Codeception\Module\Symfony\ValidatorAssertionsTrait;
 use Codeception\TestInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use Exception;
+use Codeception\Module\Symfony\DataCollectorName;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Assert;
 use ReflectionClass;
 use ReflectionException;
@@ -378,6 +379,9 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         );
     }
 
+    /**
+     * @throws AssertionFailedError
+     */
     protected function getProfile(): ?Profile
     {
         /** @var Profiler|null $profiler */
@@ -391,31 +395,29 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             return $profiler->loadProfileFromResponse($this->getClient()->getResponse());
         } catch (BadMethodCallException) {
             Assert::fail('You must perform a request before using this method.');
-        } catch (Exception $e) {
-            Assert::fail($e->getMessage());
         }
     }
 
     /**
      * Grab a Symfony Data Collector from the current profile.
      *
-     * @return EventDataCollector|FormDataCollector|HttpClientDataCollector|LoggerDataCollector|TimeDataCollector|TranslationDataCollector|TwigDataCollector|DataCollectorInterface|SecurityDataCollector|MessageDataCollector
-     *
      * @phpstan-return (
-     *     $collector is 'events' ? EventDataCollector :
-     *     ($collector is 'form' ? FormDataCollector :
-     *     ($collector is 'http_client' ? HttpClientDataCollector :
-     *     ($collector is 'logger' ? LoggerDataCollector :
-     *     ($collector is 'time' ? TimeDataCollector :
-     *     ($collector is 'translation' ? TranslationDataCollector :
-     *     ($collector is 'twig' ? TwigDataCollector :
-     *     ($collector is 'security' ? SecurityDataCollector :
-     *     ($collector is 'mailer' ? MessageDataCollector :
+     *     $collector is DataCollectorName::EVENTS ? EventDataCollector :
+     *     ($collector is DataCollectorName::FORM ? FormDataCollector :
+     *     ($collector is DataCollectorName::HTTP_CLIENT ? HttpClientDataCollector :
+     *     ($collector is DataCollectorName::LOGGER ? LoggerDataCollector :
+     *     ($collector is DataCollectorName::TIME ? TimeDataCollector :
+     *     ($collector is DataCollectorName::TRANSLATION ? TranslationDataCollector :
+     *     ($collector is DataCollectorName::TWIG ? TwigDataCollector :
+     *     ($collector is DataCollectorName::SECURITY ? SecurityDataCollector :
+     *     ($collector is DataCollectorName::MAILER ? MessageDataCollector :
      *      DataCollectorInterface
      *     ))))))))
      * )
+     *
+     * @throws AssertionFailedError
      */
-    protected function grabCollector(string $collector, string $function, ?string $message = null): DataCollectorInterface
+    protected function grabCollector(DataCollectorName $collector, string $function, ?string $message = null): DataCollectorInterface
     {
         $profile = $this->getProfile();
 
@@ -423,11 +425,17 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             Assert::fail(sprintf("The Profile is needed to use the '%s' function.", $function));
         }
 
-        if (!$profile->hasCollector($collector)) {
-            Assert::fail($message ?: "The '{$collector}' collector is needed to use the '{$function}' function.");
+        if (!$profile->hasCollector($collector->value)) {
+            Assert::fail(
+                $message ?: sprintf(
+                    "The '%s' collector is needed to use the '%s' function.",
+                    $collector->value,
+                    $function
+                )
+            );
         }
 
-        return $profile->getCollector($collector);
+        return $profile->getCollector($collector->value);
     }
 
     /**
@@ -442,22 +450,22 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             return;
         }
 
-        if ($profile->hasCollector('security')) {
-            $securityCollector = $profile->getCollector('security');
+        if ($profile->hasCollector(DataCollectorName::SECURITY->value)) {
+            $securityCollector = $profile->getCollector(DataCollectorName::SECURITY->value);
             if ($securityCollector instanceof SecurityDataCollector) {
                 $this->debugSecurityData($securityCollector);
             }
         }
 
-        if ($profile->hasCollector('mailer')) {
-            $mailerCollector = $profile->getCollector('mailer');
+        if ($profile->hasCollector(DataCollectorName::MAILER->value)) {
+            $mailerCollector = $profile->getCollector(DataCollectorName::MAILER->value);
             if ($mailerCollector instanceof MessageDataCollector) {
                 $this->debugMailerData($mailerCollector);
             }
         }
 
-        if ($profile->hasCollector('time')) {
-            $timeCollector = $profile->getCollector('time');
+        if ($profile->hasCollector(DataCollectorName::TIME->value)) {
+            $timeCollector = $profile->getCollector(DataCollectorName::TIME->value);
             if ($timeCollector instanceof TimeDataCollector) {
                 $this->debugTimeData($timeCollector);
             }

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -32,33 +32,41 @@ use Codeception\Module\Symfony\ValidatorAssertionsTrait;
 use Codeception\TestInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
-use LogicException;
+use PHPUnit\Framework\Assert;
 use ReflectionClass;
 use ReflectionException;
+use Symfony\Bridge\Twig\DataCollector\TwigDataCollector;
 use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Form\Extension\DataCollector\FormDataCollector;
+use Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
 use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
+use Symfony\Component\Translation\DataCollector\TranslationDataCollector;
 use Symfony\Component\VarDumper\Cloner\Data;
 use function array_keys;
 use function array_map;
 use function array_unique;
+use function array_values;
 use function class_exists;
 use function codecept_root_dir;
 use function count;
 use function file_exists;
 use function implode;
+use function in_array;
 use function ini_get;
 use function ini_set;
+use function is_object;
 use function iterator_to_array;
-use function number_format;
 use function sprintf;
 
 /**
@@ -132,7 +140,6 @@ use function sprintf;
  *
  * If you're using Symfony with Eloquent ORM (instead of Doctrine), you can load the [`ORM` part of Laravel module](https://codeception.com/docs/modules/Laravel#Parts)
  * in addition to Symfony module.
- *
  */
 class Symfony extends Framework implements DoctrineProvider, PartedModule
 {
@@ -158,40 +165,54 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
     public Kernel $kernel;
 
-    /**
-     * @var SymfonyConnector
-     */
+    /** @var SymfonyConnector|null */
     public ?AbstractBrowser $client = null;
 
     /**
-     * @var array<string, mixed>
+     * @var array{
+     *     app_path:string,
+     *     kernel_class:string,
+     *     environment:string,
+     *     debug:bool,
+     *     cache_router:bool,
+     *     em_service:string,
+     *     rebootable_client:bool,
+     *     authenticator:bool,
+     *     bootstrap:bool,
+     *     guard:bool
+     * }
      */
     public array $config = [
-        'app_path' => 'app',
-        'kernel_class' => 'App\Kernel',
-        'environment' => 'test',
-        'debug' => true,
-        'cache_router' => false,
-        'em_service' => 'doctrine.orm.entity_manager',
+        'app_path'          => 'app',
+        'kernel_class'      => 'App\\Kernel',
+        'environment'       => 'test',
+        'debug'             => true,
+        'cache_router'      => false,
+        'em_service'        => 'doctrine.orm.entity_manager',
         'rebootable_client' => true,
-        'authenticator' => false,
-        'bootstrap' => false,
-        'guard' => false
+        'authenticator'     => false,
+        'bootstrap'         => false,
+        'guard'             => false,
     ];
 
+    /** @var class-string<Kernel>|null */
     protected ?string $kernelClass = null;
+
     /**
      * Services that should be persistent permanently for all tests
+     *
+     * @var array<string, object>
      */
     protected array $permanentServices = [];
+
     /**
      * Services that should be persistent during test execution between kernel reboots
+     *
+     * @var array<string, object>
      */
     protected array $persistentServices = [];
 
-    /**
-     * @return string[]
-     */
+    /** @return list<string> */
     public function _parts(): array
     {
         return ['services'];
@@ -201,36 +222,56 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     {
         $this->kernelClass = $this->getKernelClass();
         $this->setXdebugMaxNestingLevel(200);
-        $this->kernel = new $this->kernelClass($this->config['environment'], $this->config['debug']);
+
+        /** @var class-string<Kernel> $kernelClass */
+        $kernelClass = $this->kernelClass;
+        $this->kernel = new $kernelClass(
+            $this->config['environment'],
+            $this->config['debug']
+        );
+
         if ($this->config['bootstrap']) {
             $this->bootstrapEnvironment();
         }
+
         $this->kernel->boot();
+
         if ($this->config['cache_router']) {
             $this->persistPermanentService('router');
         }
     }
 
     /**
-     * Initialize new client instance before each test
+     * Initialize new client instance before each test.
      */
     public function _before(TestInterface $test): void
     {
         $this->persistentServices = array_merge($this->persistentServices, $this->permanentServices);
-        $this->client = new SymfonyConnector($this->kernel, $this->persistentServices, $this->config['rebootable_client']);
+
+        $this->client = new SymfonyConnector(
+            $this->kernel,
+            $this->persistentServices,
+            $this->config['rebootable_client']
+        );
     }
 
     /**
-     * Update permanent services after each test
+     * Update permanent services after each test.
      */
     public function _after(TestInterface $test): void
     {
         foreach (array_keys($this->permanentServices) as $serviceName) {
-            $this->permanentServices[$serviceName] = $this->grabService($serviceName);
+            $service = $this->getService($serviceName);
+            if (is_object($service)) {
+                $this->permanentServices[$serviceName] = $service;
+            } else {
+                unset($this->permanentServices[$serviceName]);
+            }
         }
         parent::_after($test);
     }
 
+    /** @param array<string, string|bool> $settings */
     protected function onReconfigure(array $settings = []): void
     {
         parent::_beforeSuite($settings);
@@ -238,213 +279,259 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
     }
 
     /**
-     * Retrieve Entity Manager.
-     *
-     * EM service is retrieved once and then that instance returned on each call
+     * Retrieve the Doctrine EntityManager.
+     * EntityManager service is retrieved once and then reused.
      */
     public function _getEntityManager(): EntityManagerInterface
     {
-        if ($this->kernel === null) {
-            $this->fail('Symfony module is not loaded');
-        }
-
         $emService = $this->config['em_service'];
+
         if (!isset($this->permanentServices[$emService])) {
             $this->persistPermanentService($emService);
             $container = $this->_getContainer();
-            $services = ['doctrine', 'doctrine.orm.default_entity_manager', 'doctrine.dbal.default_connection'];
-            foreach ($services as $service) {
+            foreach (
+                ['doctrine', 'doctrine.orm.default_entity_manager', 'doctrine.dbal.default_connection']
+                as $service
+            ) {
                 if ($container->has($service)) {
                     $this->persistPermanentService($service);
                 }
             }
         }
 
+        /** @var EntityManagerInterface */
         return $this->permanentServices[$emService];
     }
 
     public function _getContainer(): ContainerInterface
     {
         $container = $this->kernel->getContainer();
-
-        return $container->has('test.service_container') ? $container->get('test.service_container') : $container;
+        /** @var ContainerInterface $testContainer */
+        $testContainer = $container->has('test.service_container') ? $container->get('test.service_container') : $container;
+        return $testContainer;
     }
 
     protected function getClient(): SymfonyConnector
     {
-        return $this->client ?: $this->fail('Client is not initialized');
+        if ($this->client === null) {
+            Assert::fail('Client is not initialized');
+        }
+
+        return $this->client;
     }
 
     /**
-     * Attempts to guess the kernel location.
-     * When the Kernel is located, the file is required.
+     * Find and require the Kernel class file.
      *
-     * @return string The Kernel class name
+     * @return class-string<Kernel>
      * @throws ModuleRequireException|ReflectionException
      */
     protected function getKernelClass(): string
     {
-        $path = codecept_root_dir() . $this->config['app_path'];
+        /** @var string $rootDir */
+        $rootDir = codecept_root_dir();
+        $path    = $rootDir . $this->config['app_path'];
+
         if (!file_exists($path)) {
             throw new ModuleRequireException(
                 self::class,
-                "Can't load Kernel from {$path}.\n"
-                . 'Directory does not exist. Set `app_path` in your suite configuration to a valid application path.'
+                "Can't load Kernel from {$path}.\n" .
+                'Directory does not exist. Set `app_path` in your suite configuration to a valid application path.'
             );
         }
 
         $this->requireAdditionalAutoloader();
 
-        $finder = new Finder();
+        $finder  = new Finder();
         $results = iterator_to_array($finder->name('*Kernel.php')->depth('0')->in($path));
+
         if ($results === []) {
             throw new ModuleRequireException(
                 self::class,
-                "File with Kernel class was not found at {$path}.\n"
-                . 'Specify directory where file with Kernel class for your application is located with `app_path` parameter.'
+                "File with Kernel class was not found at {$path}.\n" .
+                'Specify directory where file with Kernel class for your application is located with `app_path` parameter.'
             );
         }
 
-        $kernelClass = $this->config['kernel_class'];
-        $filesRealPath = array_map(static function ($file) {
-            require_once $file;
-            return $file->getRealPath();
-        }, $results);
+        $kernelClass   = $this->config['kernel_class'];
+        $filesRealPath = [];
+
+        foreach ($results as $file) {
+            include_once $file->getRealPath();
+            $filesRealPath[] = $file->getRealPath();
+        }
 
         if (class_exists($kernelClass)) {
-            $reflectionClass = new ReflectionClass($kernelClass);
-            if (in_array($reflectionClass->getFileName(), $filesRealPath, true)) {
+            $ref      = new ReflectionClass($kernelClass);
+            $fileName = $ref->getFileName();
+            if ($fileName !== false && in_array($fileName, $filesRealPath, true)) {
+                /** @var class-string<Kernel> $kernelClass */
                 return $kernelClass;
             }
         }
 
         throw new ModuleRequireException(
             self::class,
-            "Kernel class was not found.\n"
-            . 'Specify directory where file with Kernel class for your application is located with `kernel_class` parameter.'
+            "Kernel class was not found.\n" .
+            'Specify directory where file with Kernel class for your application is located with `kernel_class` parameter.'
         );
     }
 
     protected function getProfile(): ?Profile
     {
-        /** @var Profiler $profiler */
+        /** @var Profiler|null $profiler */
         $profiler = $this->getService('profiler');
-        try {
-            return $profiler?->loadProfileFromResponse($this->getClient()->getResponse());
-        } catch (BadMethodCallException) {
-            $this->fail('You must perform a request before using this method.');
-        } catch (Exception $e) {
-            $this->fail($e->getMessage());
+
+        if ($profiler === null) {
+            return null;
         }
 
-        return null;
+        try {
+            return $profiler->loadProfileFromResponse($this->getClient()->getResponse());
+        } catch (BadMethodCallException) {
+            Assert::fail('You must perform a request before using this method.');
+        } catch (Exception $e) {
+            Assert::fail($e->getMessage());
+        }
     }
 
     /**
-     * Grabs a Symfony Data Collector
+     * Grab a Symfony Data Collector from the current profile.
+     *
+     * @return EventDataCollector|FormDataCollector|HttpClientDataCollector|LoggerDataCollector|TimeDataCollector|TranslationDataCollector|TwigDataCollector|DataCollectorInterface|SecurityDataCollector|MessageDataCollector
+     *
+     * @phpstan-return (
+     *     $collector is 'events' ? EventDataCollector :
+     *     ($collector is 'form' ? FormDataCollector :
+     *     ($collector is 'http_client' ? HttpClientDataCollector :
+     *     ($collector is 'logger' ? LoggerDataCollector :
+     *     ($collector is 'time' ? TimeDataCollector :
+     *     ($collector is 'translation' ? TranslationDataCollector :
+     *     ($collector is 'twig' ? TwigDataCollector :
+     *     ($collector is 'security' ? SecurityDataCollector :
+     *     ($collector is 'mailer' ? MessageDataCollector :
+     *      DataCollectorInterface
+     *     ))))))))
+     * )
      */
     protected function grabCollector(string $collector, string $function, ?string $message = null): DataCollectorInterface
     {
         $profile = $this->getProfile();
+
         if ($profile === null) {
-            $this->fail(sprintf("The Profile is needed to use the '%s' function.", $function));
+            Assert::fail(sprintf("The Profile is needed to use the '%s' function.", $function));
         }
+
         if (!$profile->hasCollector($collector)) {
-            $this->fail($message ?: "The '{$collector}' collector is needed to use the '{$function}' function.");
+            Assert::fail($message ?: "The '{$collector}' collector is needed to use the '{$function}' function.");
         }
 
         return $profile->getCollector($collector);
     }
 
     /**
-     * Set the data that will be displayed when running a test with the `--debug` flag
-     *
-     * @param mixed $url
+     * Set the data that will be displayed when running a test with the `--debug` flag.
      */
-    protected function debugResponse($url): void
+    protected function debugResponse(mixed $url): void
     {
         parent::debugResponse($url);
-        if ($profile = $this->getProfile()) {
-            $collectors = [
-                'security' => 'debugSecurityData',
-                'mailer'   => 'debugMailerData',
-                'time'     => 'debugTimeData',
-            ];
-            foreach ($collectors as $collector => $method) {
-                if ($profile->hasCollector($collector)) {
-                    $this->$method($profile->getCollector($collector));
+
+        $profile = $this->getProfile();
+        if ($profile === null) {
+            return;
+        }
+
+        if ($profile->hasCollector('security')) {
+            $securityCollector = $profile->getCollector('security');
+            if ($securityCollector instanceof SecurityDataCollector) {
+                $this->debugSecurityData($securityCollector);
+            }
+        }
+
+        if ($profile->hasCollector('mailer')) {
+            $mailerCollector = $profile->getCollector('mailer');
+            if ($mailerCollector instanceof MessageDataCollector) {
+                $this->debugMailerData($mailerCollector);
+            }
+        }
+
+        if ($profile->hasCollector('time')) {
+            $timeCollector = $profile->getCollector('time');
+            if ($timeCollector instanceof TimeDataCollector) {
+                $this->debugTimeData($timeCollector);
+            }
+        }
+    }
+
+    /** @return list<non-empty-string> */
+    protected function getInternalDomains(): array
+    {
+        $domains = [];
+
+        foreach ($this->grabRouterService()->getRouteCollection() as $route) {
+            if ($route->getHost() !== '') {
+                $regex = $route->compile()->getHostRegex();
+                if ($regex !== null && $regex !== '') {
+                    $domains[] = $regex;
                 }
             }
+        }
+
+        /** @var list<non-empty-string> */
+        return array_values(array_unique($domains));
+    }
+
+    /**
+     * Ensure Xdebug allows deep nesting.
+     */
+    private function setXdebugMaxNestingLevel(int $max): void
+    {
+        if ((int) ini_get('xdebug.max_nesting_level') < $max) {
+            ini_set('xdebug.max_nesting_level', (string) $max);
         }
     }
 
     /**
-     * Returns a list of recognized domain names.
+     * Bootstrap environment via tests/bootstrap.php or Dotenv.
      */
-    protected function getInternalDomains(): array
-    {
-        $internalDomains = [];
-        $router = $this->grabRouterService();
-        $routes = $router->getRouteCollection();
-
-        foreach ($routes as $route) {
-            if ($route->getHost() !== null) {
-                $compiledRoute = $route->compile();
-                if ($compiledRoute->getHostRegex() !== null) {
-                    $internalDomains[] = $compiledRoute->getHostRegex();
-                }
-            }
-        }
-
-        return array_unique($internalDomains);
-    }
-
-    private function setXdebugMaxNestingLevel(int $maxNestingLevel): void
-    {
-        if (ini_get('xdebug.max_nesting_level') < $maxNestingLevel) {
-            ini_set('xdebug.max_nesting_level', (string)$maxNestingLevel);
-        }
-    }
-
     private function bootstrapEnvironment(): void
     {
         $bootstrapFile = $this->kernel->getProjectDir() . '/tests/bootstrap.php';
+
         if (file_exists($bootstrapFile)) {
-            require_once $bootstrapFile;
-        } else {
-            if (!method_exists(Dotenv::class, 'bootEnv')) {
-                throw new LogicException(
-                    "Symfony DotEnv is missing. Try running 'composer require symfony/dotenv'\n" .
-                    "If you can't install DotEnv add your env files to the 'params' key in codeception.yml\n" .
-                    "or update your symfony/framework-bundle recipe by running:\n" .
-                    'composer recipes:install symfony/framework-bundle --force'
-                );
-            }
-            $_ENV['APP_ENV'] = $this->config['environment'];
-            (new Dotenv())->bootEnv('.env');
+            include_once $bootstrapFile;
+            return;
         }
+
+        $_ENV['APP_ENV'] = $this->config['environment'];
+        (new Dotenv())->bootEnv('.env');
     }
 
-    private function debugSecurityData(SecurityDataCollector $security): void
+    private function debugSecurityData(SecurityDataCollector $securityCollector): void
     {
-        if ($security->isAuthenticated()) {
-            $roles = $security->getRoles();
-            $rolesString = implode(',', $roles instanceof Data ? $roles->getValue() : $roles);
-            $userInfo = $security->getUser() . ' [' . $rolesString . ']';
-        } else {
-            $userInfo = 'Anonymous';
+        if (!$securityCollector->isAuthenticated()) {
+            $this->debugSection('User', 'Anonymous');
+            return;
         }
-        $this->debugSection('User', $userInfo);
+
+        $roles = $securityCollector->getRoles();
+        if ($roles instanceof Data) {
+            $roles = $roles->getValue(true);
+        }
+
+        $rolesStr = implode(',', array_map('strval', array_filter((array) $roles, 'is_scalar')));
+        $this->debugSection('User', sprintf('%s [%s]', $securityCollector->getUser(), $rolesStr));
     }
 
-    private function debugMailerData(MessageDataCollector $mailerCollector): void
+    private function debugMailerData(MessageDataCollector $messageCollector): void
     {
-        $this->debugSection('Emails', count($mailerCollector->getEvents()->getMessages()) . ' sent');
+        $count = count($messageCollector->getEvents()->getMessages());
+        $this->debugSection('Emails', sprintf('%d sent', $count));
     }
 
     private function debugTimeData(TimeDataCollector $timeCollector): void
     {
-        $this->debugSection('Time', number_format($timeCollector->getDuration(), 2) . ' ms');
+        $this->debugSection('Time', sprintf('%.2f ms', $timeCollector->getDuration()));
     }
 
     /**
@@ -453,9 +540,12 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     private function requireAdditionalAutoloader(): void
     {
-        $autoLoader = codecept_root_dir() . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
-        if (file_exists($autoLoader)) {
-            require_once $autoLoader;
+        /** @var string $rootDir */
+        $rootDir  = codecept_root_dir();
+        $autoload = $rootDir . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+        if (file_exists($autoload)) {
+            include_once $autoload;
         }
     }
 }

--- a/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
@@ -23,10 +23,10 @@ trait ConsoleAssertionsTrait
      * $result = $I->runSymfonyConsoleCommand('hello:world', ['arg' => 'argValue', 'opt1' => 'optValue'], ['input']);
      * ```
      *
-     * @param  string                    $command          The console command to execute.
-     * @param  array<string, int|string> $parameters       Arguments and options passed to the command
-     * @param  list<string>              $consoleInputs    Inputs for interactive questions.
-     * @param  int                       $expectedExitCode Expected exit code.
+     * @param string                             $command          The console command to execute.
+     * @param array<int|string, int|string|bool> $parameters       Arguments and options passed to the command
+     * @param list<string>                       $consoleInputs    Inputs for interactive questions.
+     * @param int                                $expectedExitCode Expected exit code.
      * @return string Console output (stdout).
      */
     public function runSymfonyConsoleCommand(
@@ -56,8 +56,8 @@ trait ConsoleAssertionsTrait
     }
 
     /**
-     * @param  array<string, int|string|bool> $parameters
-     * @return array<string, mixed> Options array supported by CommandTester.
+     * @param array<int|string, int|string|bool> $parameters
+     * @return array<string, bool|int> Options array supported by CommandTester.
      */
     private function configureOptions(array $parameters): array
     {
@@ -101,6 +101,8 @@ trait ConsoleAssertionsTrait
 
     protected function grabKernelService(): KernelInterface
     {
-        return $this->grabService('kernel');
+        /** @var KernelInterface $kernel */
+        $kernel = $this->grabService(KernelInterface::class);
+        return $kernel;
     }
 }

--- a/src/Codeception/Module/Symfony/DataCollectorName.php
+++ b/src/Codeception/Module/Symfony/DataCollectorName.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Module\Symfony;
+
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
+use Symfony\Component\Form\Extension\DataCollector\FormDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
+use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
+use Symfony\Component\Translation\DataCollector\TranslationDataCollector;
+use Symfony\Bridge\Twig\DataCollector\TwigDataCollector;
+use Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector;
+use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
+use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
+
+/**
+ * @internal
+ */
+enum DataCollectorName: string
+{
+    case EVENTS = 'events';
+    case FORM = 'form';
+    case HTTP_CLIENT = 'http_client';
+    case LOGGER = 'logger';
+    case TIME = 'time';
+    case TRANSLATION = 'translation';
+    case TWIG = 'twig';
+    case SECURITY = 'security';
+    case MAILER = 'mailer';
+
+    /**
+     * @return class-string<DataCollectorInterface>
+     */
+    public function collectorClass(): string
+    {
+        return match ($this) {
+            self::EVENTS => EventDataCollector::class,
+            self::FORM => FormDataCollector::class,
+            self::HTTP_CLIENT => HttpClientDataCollector::class,
+            self::LOGGER => LoggerDataCollector::class,
+            self::TIME => TimeDataCollector::class,
+            self::TRANSLATION => TranslationDataCollector::class,
+            self::TWIG => TwigDataCollector::class,
+            self::SECURITY => SecurityDataCollector::class,
+            self::MAILER => MessageDataCollector::class,
+        };
+    }
+}

--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Module\Symfony\DataCollectorName;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
 
@@ -304,6 +305,6 @@ trait EventsAssertionsTrait
 
     protected function grabEventCollector(string $function): EventDataCollector
     {
-        return $this->grabCollector('events', $function);
+        return $this->grabCollector(DataCollectorName::EVENTS, $function);
     }
 }

--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -4,49 +4,55 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpKernel\DataCollector\EventDataCollector;
+
+use function array_column;
+use function array_merge;
+use function count;
+use function in_array;
 use function is_array;
 use function is_object;
+use function is_string;
+use function str_starts_with;
 
 trait EventsAssertionsTrait
 {
     /**
-     * Verifies that there were no events during the test.
-     * Both regular and orphan events are checked.
+     * Verifies that **no** events (regular **or** orphan) were dispatched during the test.
      *
      * ```php
-     *  <?php
-     *  $I->dontSeeEvent();
-     *  $I->dontSeeEvent('App\MyEvent');
-     *  $I->dontSeeEvent(['App\MyEvent', 'App\MyOtherEvent']);
-     *  ```
+     * <?php
+     * $I->dontSeeEvent();
+     * $I->dontSeeEvent('App\MyEvent');
+     * $I->dontSeeEvent(['App\MyEvent', 'App\MyOtherEvent']);
+     * ```
      *
-     * @param string|string[]|null $expected
+     * @param class-string|list<class-string>|null $expected Fully-qualified event class(es) that must **not** appear.
      */
     public function dontSeeEvent(array|string|null $expected = null): void
     {
-        $actualEvents = [...array_column($this->getCalledListeners(), 'event')];
-        $actual = [$this->getOrphanedEvents(), $actualEvents];
-        $this->assertEventTriggered(false, $expected, $actual);
+        $actual = $this->collectEvents(orphanOnly: false);
+        $this->assertEventTriggered($expected, $actual, shouldExist: false);
     }
 
     /**
-     * Verifies that one or more event listeners were not called during the test.
+     * Verifies that one or more **listeners** were **not** called during the test.
      *
      * ```php
      * <?php
      * $I->dontSeeEventListenerIsCalled('App\MyEventListener');
      * $I->dontSeeEventListenerIsCalled(['App\MyEventListener', 'App\MyOtherEventListener']);
-     * $I->dontSeeEventListenerIsCalled('App\MyEventListener', 'my.event);
+     * $I->dontSeeEventListenerIsCalled('App\MyEventListener', 'my.event');
      * $I->dontSeeEventListenerIsCalled('App\MyEventListener', ['my.event', 'my.other.event']);
      * ```
      *
-     * @param class-string|class-string[] $expected
-     * @param string|string[] $events
+     * @param class-string|object|list<class-string|object> $expected Listeners (class-strings or object instances).
+     * @param string|list<string>                           $events   Event name(s) (empty = any).
      */
     public function dontSeeEventListenerIsCalled(array|object|string $expected, array|string $events = []): void
     {
-        $this->assertListenerCalled(false, $expected, $events);
+        $this->assertListenerCalled($expected, $events, shouldBeCalled: false);
     }
 
     /**
@@ -59,8 +65,8 @@ trait EventsAssertionsTrait
      * $I->dontSeeEventTriggered(['App\MyEvent', 'App\MyOtherEvent']);
      * ```
      *
-     * @param object|string|string[] $expected
-     * @deprecated Use `dontSeeEventListenerIsCalled` instead.
+     * @param      class-string|object|list<class-string|object> $expected
+     * @deprecated Use {@see dontSeeEventListenerIsCalled()} instead.
      */
     public function dontSeeEventTriggered(array|object|string $expected): void
     {
@@ -75,8 +81,8 @@ trait EventsAssertionsTrait
      * Verifies that there were no orphan events during the test.
      *
      * An orphan event is an event that was triggered by manually executing the
-     * [`dispatch()`](https://symfony.com/doc/current/components/event_dispatcher.html#dispatch-the-event) method
-     * of the EventDispatcher but was not handled by any listener after it was dispatched.
+     * {@link https://symfony.com/doc/current/components/event_dispatcher.html#dispatch-the-event dispatch()}
+     * method of the EventDispatcher but was not handled by any listener after it was dispatched.
      *
      * ```php
      * <?php
@@ -85,53 +91,48 @@ trait EventsAssertionsTrait
      * $I->dontSeeOrphanEvent(['App\MyEvent', 'App\MyOtherEvent']);
      * ```
      *
-     * @param string|string[] $expected
+     * @param class-string|list<class-string>|null $expected Event class(es) that must **not** appear as orphan.
      */
     public function dontSeeOrphanEvent(array|string|null $expected = null): void
     {
-        $actual = [$this->getOrphanedEvents()];
-        $this->assertEventTriggered(false, $expected, $actual);
+        $actual = $this->collectEvents(orphanOnly: true);
+        $this->assertEventTriggered($expected, $actual, shouldExist: false);
     }
 
     /**
-     * Verifies that one or more events were dispatched during the test.
-     * Both regular and orphan events are checked.
-     *
-     * If you need to verify that expected event is not orphan,
-     * add `dontSeeOrphanEvent` call.
+     * Verifies that at least one of the given events **was** dispatched (regular **or** orphan).
      *
      * ```php
-     *  <?php
-     *  $I->seeEvent('App\MyEvent');
-     *  $I->seeEvent(['App\MyEvent', 'App\MyOtherEvent']);
-     *  ```
+     * <?php
+     * $I->seeEvent('App\MyEvent');
+     * $I->seeEvent(['App\MyEvent', 'App\MyOtherEvent']);
+     * ```
      *
-     * @param string|string[] $expected
+     * @param class-string|list<class-string> $expected Fully-qualified class-name(s) of the expected event(s).
      */
     public function seeEvent(array|string $expected): void
     {
-        $actualEvents = [...array_column($this->getCalledListeners(), 'event')];
-        $actual = [$this->getOrphanedEvents(), $actualEvents];
-        $this->assertEventTriggered(true, $expected, $actual);
+        $actual = $this->collectEvents(orphanOnly: false);
+        $this->assertEventTriggered($expected, $actual, shouldExist: true);
     }
 
     /**
-     * Verifies that one or more event listeners were called during the test.
+     * Verifies that one or more **listeners** were called during the test.
      *
      * ```php
      * <?php
      * $I->seeEventListenerIsCalled('App\MyEventListener');
      * $I->seeEventListenerIsCalled(['App\MyEventListener', 'App\MyOtherEventListener']);
-     * $I->seeEventListenerIsCalled('App\MyEventListener', 'my.event);
+     * $I->seeEventListenerIsCalled('App\MyEventListener', 'my.event');
      * $I->seeEventListenerIsCalled('App\MyEventListener', ['my.event', 'my.other.event']);
      * ```
      *
-     * @param class-string|class-string[] $expected
-     * @param string|string[] $events
+     * @param class-string|object|list<class-string|object> $expected Listeners (class-strings or object instances).
+     * @param string|list<string>                           $events   Event name(s) (empty = any).
      */
     public function seeEventListenerIsCalled(array|object|string $expected, array|string $events = []): void
     {
-        $this->assertListenerCalled(true, $expected, $events);
+        $this->assertListenerCalled($expected, $events, shouldBeCalled: true);
     }
 
     /**
@@ -144,8 +145,8 @@ trait EventsAssertionsTrait
      * $I->seeEventTriggered(['App\MyEvent', 'App\MyOtherEvent']);
      * ```
      *
-     * @param object|string|string[] $expected
-     * @deprecated Use `seeEventListenerIsCalled` instead.
+     * @param class-string|object|list<class-string|object> $expected
+     * @deprecated Use {@see seeEventListenerIsCalled()} instead.
      */
     public function seeEventTriggered(array|object|string $expected): void
     {
@@ -157,11 +158,11 @@ trait EventsAssertionsTrait
     }
 
     /**
-     * Verifies that one or more orphan events were dispatched during the test.
+     * Verifies that one or more orphan events **were** dispatched during the test.
      *
      * An orphan event is an event that was triggered by manually executing the
-     * [`dispatch()`](https://symfony.com/doc/current/components/event_dispatcher.html#dispatch-the-event) method
-     * of the EventDispatcher but was not handled by any listener after it was dispatched.
+     * {@link https://symfony.com/doc/current/components/event_dispatcher.html#dispatch-the-event dispatch()}
+     * method of the EventDispatcher but was not handled by any listener after it was dispatched.
      *
      * ```php
      * <?php
@@ -169,84 +170,125 @@ trait EventsAssertionsTrait
      * $I->seeOrphanEvent(['App\MyEvent', 'App\MyOtherEvent']);
      * ```
      *
-     * @param string|string[] $expected
+     * @param class-string|list<class-string> $expected Event class-name(s) expected to be orphan.
      */
     public function seeOrphanEvent(array|string $expected): void
     {
-        $actual = [$this->getOrphanedEvents()];
-        $this->assertEventTriggered(true, $expected, $actual);
+        $actual = $this->collectEvents(orphanOnly: true);
+        $this->assertEventTriggered($expected, $actual, shouldExist: true);
     }
 
-    protected function getCalledListeners(): array
+    /** @return list<array{event: string, pretty: string}> */
+    protected function getDispatchedEvents(): array
     {
-        $eventCollector = $this->grabEventCollector(__FUNCTION__);
+        $eventCollector  = $this->grabEventCollector(__FUNCTION__);
         $calledListeners = $eventCollector->getCalledListeners($this->getDefaultDispatcher());
-        return [...$calledListeners->getValue(true)];
+
+        /** @var list<array{event: string, pretty: string}> */
+        return is_array($calledListeners)
+            ? array_values($calledListeners)
+            : $calledListeners->getValue(true);
     }
 
+    /** @return list<string> */
     protected function getOrphanedEvents(): array
     {
         $eventCollector = $this->grabEventCollector(__FUNCTION__);
         $orphanedEvents = $eventCollector->getOrphanedEvents($this->getDefaultDispatcher());
-        return [...$orphanedEvents->getValue(true)];
+
+        /** @var list<string> */
+        return is_array($orphanedEvents)
+            ? array_values($orphanedEvents)
+            : $orphanedEvents->getValue(true);
     }
 
-    protected function assertEventTriggered(bool $assertTrue, array|object|string|null $expected, array $actual): void
+    /** @return list<list<string>> */
+    private function collectEvents(bool $orphanOnly): array
+    {
+        return $orphanOnly
+            ? [$this->getOrphanedEvents()]
+            : [$this->getOrphanedEvents(), array_column($this->getDispatchedEvents(), 'event')];
+    }
+
+    /**
+     * @param class-string|object|list<class-string|object>|null $expected
+     * @param list<list<string>>                                 $actual
+     */
+    protected function assertEventTriggered(array|object|string|null $expected, array $actual, bool $shouldExist): void
     {
         $actualEvents = array_merge(...$actual);
 
-        if ($assertTrue) $this->assertNotEmpty($actualEvents, 'No event was triggered');
+        if ($shouldExist) {
+            $this->assertNotEmpty($actualEvents, 'No event was triggered.');
+        }
         if ($expected === null) {
             $this->assertEmpty($actualEvents);
             return;
         }
 
-        $expected = is_object($expected) ? $expected::class : $expected;
-        foreach ((array)$expected as $expectedEvent) {
-            $expectedEvent = is_object($expectedEvent) ? $expectedEvent::class : $expectedEvent;
-            $eventTriggered = in_array($expectedEvent, $actualEvents);
+        $expectedEvents = is_object($expected) ? [$expected] : (array) $expected;
+        foreach ($expectedEvents as $expectedEvent) {
+            $eventName    = is_object($expectedEvent) ? $expectedEvent::class : $expectedEvent;
+            $wasTriggered = in_array($eventName, $actualEvents, true);
 
-            $message = $assertTrue
-                ? "The '{$expectedEvent}' event did not trigger"
-                : "The '{$expectedEvent}' event triggered";
-            $this->assertSame($assertTrue, $eventTriggered, $message);
+            $this->assertSame(
+                $shouldExist,
+                $wasTriggered,
+                sprintf("The '%s' event %s triggered", $eventName, $shouldExist ? 'did not' : 'was')
+            );
         }
     }
 
-    protected function assertListenerCalled(bool $assertTrue, array|object|string $expectedListeners, array|object|string $expectedEvents): void
-    {
+    /**
+     * @param class-string|object|list<class-string|object> $expectedListeners
+     * @param string|list<string>                           $expectedEvents
+     */
+    protected function assertListenerCalled(
+        array|object|string $expectedListeners,
+        array|string $expectedEvents,
+        bool $shouldBeCalled
+    ): void {
         $expectedListeners = is_array($expectedListeners) ? $expectedListeners : [$expectedListeners];
-        $expectedEvents = is_array($expectedEvents) ? $expectedEvents : [$expectedEvents];
+        $expectedEvents    = is_array($expectedEvents) ? $expectedEvents : [$expectedEvents];
 
-        if (empty($expectedEvents)) {
+        if ($expectedEvents === []) {
             $expectedEvents = [null];
         } elseif (count($expectedListeners) > 1) {
-            $this->fail('You cannot check for events when using multiple listeners. Make multiple assertions instead.');
+            Assert::fail('Cannot check for events when using multiple listeners. Make multiple assertions instead.');
         }
 
-        $actualEvents = $this->getCalledListeners();
-        if ($assertTrue && empty($actualEvents)) {
-            $this->fail('No event listener was called');
+        $actualEvents = $this->getDispatchedEvents();
+
+        if ($shouldBeCalled && $actualEvents === []) {
+            Assert::fail('No event listener was called.');
         }
 
         foreach ($expectedListeners as $expectedListener) {
-            $expectedListener = is_object($expectedListener) ? $expectedListener::class : $expectedListener;
+            $expectedListener = is_string($expectedListener) ? $expectedListener : $expectedListener::class;
 
             foreach ($expectedEvents as $expectedEvent) {
-                $listenerCalled = $this->listenerWasCalled($expectedListener, $expectedEvent, $actualEvents);
-                $message = "The '{$expectedListener}' listener was called"
-                    . ($expectedEvent ? " for the '{$expectedEvent}' event" : '');
-                $this->assertSame($assertTrue, $listenerCalled, $message);
+                $eventName = $expectedEvent ?: null;
+                $wasCalled = $this->listenerWasCalled($expectedListener, $eventName, $actualEvents);
+
+                $this->assertSame(
+                    $shouldBeCalled,
+                    $wasCalled,
+                    sprintf(
+                        "The '%s' listener was %scalled%s",
+                        $expectedListener,
+                        $shouldBeCalled ? 'not ' : '',
+                        $eventName ? " for the '{$eventName}' event" : ''
+                    )
+                );
             }
         }
     }
 
+    /** @param list<array{event: string, pretty: string}> $actualEvents */
     private function listenerWasCalled(string $expectedListener, ?string $expectedEvent, array $actualEvents): bool
     {
         foreach ($actualEvents as $actualEvent) {
-            if (
-                isset($actualEvent['pretty'], $actualEvent['event'])
-                && str_starts_with($actualEvent['pretty'], $expectedListener)
+            if (str_starts_with($actualEvent['pretty'], $expectedListener)
                 && ($expectedEvent === null || $actualEvent['event'] === $expectedEvent)
             ) {
                 return true;

--- a/src/Codeception/Module/Symfony/FormAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/FormAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Module\Symfony\DataCollectorName;
 use Symfony\Component\Form\Extension\DataCollector\FormDataCollector;
 use Symfony\Component\VarDumper\Cloner\Data;
 use function is_array;
@@ -227,6 +228,6 @@ trait FormAssertionsTrait
 
     protected function grabFormCollector(string $function): FormDataCollector
     {
-        return $this->grabCollector('form', $function);
+        return $this->grabCollector(DataCollectorName::FORM, $function);
     }
 }

--- a/src/Codeception/Module/Symfony/FormAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/FormAssertionsTrait.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Codeception\Module\Symfony;
 
 use Symfony\Component\Form\Extension\DataCollector\FormDataCollector;
-use function array_key_exists;
-use function in_array;
+use Symfony\Component\VarDumper\Cloner\Data;
+use function is_array;
 use function is_int;
+use function is_string;
 use function sprintf;
 
 trait FormAssertionsTrait
@@ -22,10 +23,15 @@ trait FormAssertionsTrait
      */
     public function assertFormValue(string $formSelector, string $fieldName, string $value, string $message = ''): void
     {
-        $node = $this->getCLient()->getCrawler()->filter($formSelector);
+        $node = $this->getClient()->getCrawler()->filter($formSelector);
         $this->assertNotEmpty($node, sprintf('Form "%s" not found.', $formSelector));
+
         $values = $node->form()->getValues();
-        $this->assertArrayHasKey($fieldName, $values, $message ?: sprintf('Field "%s" not found in form "%s".', $fieldName, $formSelector));
+        $this->assertArrayHasKey(
+            $fieldName,
+            $values,
+            $message ?: sprintf('Field "%s" not found in form "%s".', $fieldName, $formSelector)
+        );
         $this->assertSame($value, $values[$fieldName]);
     }
 
@@ -39,10 +45,15 @@ trait FormAssertionsTrait
      */
     public function assertNoFormValue(string $formSelector, string $fieldName, string $message = ''): void
     {
-        $node = $this->getCLient()->getCrawler()->filter($formSelector);
+        $node = $this->getClient()->getCrawler()->filter($formSelector);
         $this->assertNotEmpty($node, sprintf('Form "%s" not found.', $formSelector));
+
         $values = $node->form()->getValues();
-        $this->assertArrayNotHasKey($fieldName, $values, $message ?: sprintf('Field "%s" has a value in form "%s".', $fieldName, $formSelector));
+        $this->assertArrayNotHasKey(
+            $fieldName,
+            $values,
+            $message ?: sprintf('Field "%s" has a value in form "%s".', $fieldName, $formSelector)
+        );
     }
 
     /**
@@ -56,14 +67,9 @@ trait FormAssertionsTrait
     public function dontSeeFormErrors(): void
     {
         $formCollector = $this->grabFormCollector(__FUNCTION__);
+        $errors        = $this->extractFormCollectorScalar($formCollector, 'nb_errors');
 
-        $errors = (int)$formCollector->getData()->offsetGet('nb_errors');
-
-        $this->assertSame(
-            0,
-            $errors,
-            'Expecting that the form does not have errors, but there were!'
-        );
+        $this->assertSame(0, $errors, 'Expecting that the form does not have errors, but there were!');
     }
 
     /**
@@ -79,44 +85,48 @@ trait FormAssertionsTrait
     public function seeFormErrorMessage(string $field, ?string $message = null): void
     {
         $formCollector = $this->grabFormCollector(__FUNCTION__);
+        $rawData       = $this->getRawCollectorData($formCollector);
+        $formsData     = array_values(is_array($rawData['forms'] ?? null) ? $rawData['forms'] : []);
 
-        if (!$forms = $formCollector->getData()->getValue(true)['forms']) {
-            $this->fail('No forms found on the current page.');
-        }
+        $fieldExists    = false;
+        $errorsForField = [];
 
-        $fields = [];
-        $errors = [];
-
-        foreach ($forms as $form) {
-            foreach ($form['children'] as $child) {
-                $fieldName = $child['name'];
-                $fields[] = $fieldName;
-
-                if (!array_key_exists('errors', $child)) {
+        foreach ($formsData as $form) {
+            if (!is_array($form)) {
+                continue;
+            }
+            $children = is_array($form['children'] ?? null) ? $form['children'] : [];
+            foreach ($children as $child) {
+                if (!is_array($child) || ($child['name'] ?? null) !== $field) {
                     continue;
                 }
 
-                foreach ($child['errors'] as $error) {
-                    $errors[$fieldName] = $error['message'];
+                $fieldExists = true;
+
+                $errs = is_array($child['errors'] ?? null) ? $child['errors'] : [];
+                foreach ($errs as $error) {
+                    if (is_array($error) && is_string($error['message'] ?? null)) {
+                        $errorsForField[] = $error['message'];
+                    }
                 }
             }
         }
 
-        if (!in_array($field, $fields)) {
+        if (!$fieldExists) {
             $this->fail("The field '{$field}' does not exist in the form.");
         }
 
-        if (!array_key_exists($field, $errors)) {
+        if ($errorsForField === []) {
             $this->fail("No form error message for field '{$field}'.");
         }
 
-        if (!$message) {
+        if ($message === null) {
             return;
         }
 
         $this->assertStringContainsString(
             $message,
-            $errors[$field],
+            implode("\n", $errorsForField),
             sprintf(
                 "There is an error message for the field '%s', but it does not match the expected message.",
                 $field
@@ -164,15 +174,15 @@ trait FormAssertionsTrait
      * ]);
      * ```
      *
-     * @param string[] $expectedErrors
+     * @param array<int|string, string|null> $expectedErrors
      */
     public function seeFormErrorMessages(array $expectedErrors): void
     {
-        foreach ($expectedErrors as $field => $message) {
+        foreach ($expectedErrors as $field => $msg) {
             if (is_int($field)) {
-                $this->seeFormErrorMessage($message);
+                $this->seeFormErrorMessage((string) $msg);
             } else {
-                $this->seeFormErrorMessage($field, $message);
+                $this->seeFormErrorMessage($field, $msg);
             }
         }
     }
@@ -188,12 +198,31 @@ trait FormAssertionsTrait
     public function seeFormHasErrors(): void
     {
         $formCollector = $this->grabFormCollector(__FUNCTION__);
+        $errors        = $this->extractFormCollectorScalar($formCollector, 'nb_errors');
 
-        $this->assertGreaterThan(
-            0,
-            $formCollector->getData()->offsetGet('nb_errors'),
-            'Expecting that the form has errors, but there were none!'
-        );
+        $this->assertGreaterThan(0, $errors, 'Expecting that the form has errors, but there were none!');
+    }
+
+    private function extractFormCollectorScalar(FormDataCollector $collector, string $key): int
+    {
+        $rawData  = $this->getRawCollectorData($collector);
+        $valueRaw = $rawData[$key] ?? null;
+
+        return is_numeric($valueRaw) ? (int) $valueRaw : 0;
+    }
+
+    /** @return array<string, mixed> */
+    private function getRawCollectorData(FormDataCollector $collector): array
+    {
+        $data = $collector->getData();
+
+        if ($data instanceof Data) {
+            $data = $data->getValue(true);
+        }
+
+        /** @var array<string, mixed> $result */
+        $result = is_array($data) ? $data : [];
+        return $result;
     }
 
     protected function grabFormCollector(string $function): FormDataCollector

--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Module\Symfony\DataCollectorName;
 use Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector;
 use Symfony\Component\VarDumper\Cloner\Data;
 use function array_change_key_case;
@@ -156,6 +157,6 @@ trait HttpClientAssertionsTrait
 
     protected function grabHttpClientCollector(string $function): HttpClientDataCollector
     {
-        return $this->grabCollector('http_client', $function);
+        return $this->grabCollector(DataCollectorName::HTTP_CLIENT, $function);
     }
 }

--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -5,15 +5,24 @@ declare(strict_types=1);
 namespace Codeception\Module\Symfony;
 
 use Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
+use function array_change_key_case;
+use function array_filter;
+use function array_intersect_key;
 use function array_key_exists;
-use function is_string;
+use function in_array;
+use function is_array;
+use function is_object;
+use function method_exists;
+use function sprintf;
 
 trait HttpClientAssertionsTrait
 {
     /**
-     * Asserts that the given URL has been called using, if specified, the given method body and headers.
-     * By default, it will check on the HttpClient, but you can also pass a specific HttpClient ID.
-     * (It will succeed if the request has been called multiple times.)
+     * Asserts that the given URL has been called using, if specified, the given method, body and/or headers.
+     * By default, it will inspect the default Symfony HttpClient; you may check a different one by passing its
+     * service-id in $httpClientId.
+     * It succeeds even if the request was executed multiple times.
      *
      * ```php
      * <?php
@@ -24,111 +33,125 @@ trait HttpClientAssertionsTrait
      *     ['Authorization' => 'Bearer token']
      * );
      * ```
+     *
+     * @param string|array<mixed>|null      $expectedBody
+     * @param array<string,string|string[]> $expectedHeaders
      */
-    public function assertHttpClientRequest(string $expectedUrl, string $expectedMethod = 'GET', string|array|null $expectedBody = null, array $expectedHeaders = [], string $httpClientId = 'http_client'): void
-    {
-        $httpClientCollector = $this->grabHttpClientCollector(__FUNCTION__);
-        $expectedRequestHasBeenFound = false;
-
-        if (!array_key_exists($httpClientId, $httpClientCollector->getClients())) {
-            $this->fail(sprintf('HttpClient "%s" is not registered.', $httpClientId));
-        }
-
-        foreach ($httpClientCollector->getClients()[$httpClientId]['traces'] as $trace) {
-            if (($expectedUrl !== $trace['info']['url'] && $expectedUrl !== $trace['url'])
-                || $expectedMethod !== $trace['method']
-            ) {
-                continue;
-            }
-
-            if (null !== $expectedBody) {
-                $actualBody = null;
-
-                if (null !== $trace['options']['body'] && null === $trace['options']['json']) {
-                    $actualBody = is_string($trace['options']['body']) ? $trace['options']['body'] : $trace['options']['body']->getValue(true);
+    public function assertHttpClientRequest(
+        string            $expectedUrl,
+        string            $expectedMethod = 'GET',
+        string|array|null $expectedBody   = null,
+        array             $expectedHeaders = [],
+        string            $httpClientId = 'http_client',
+    ): void {
+        $matchingRequests = array_filter(
+            $this->getHttpClientTraces($httpClientId, __FUNCTION__),
+            function (array $trace) use ($expectedUrl, $expectedMethod, $expectedBody, $expectedHeaders): bool {
+                if (!$this->matchesUrlAndMethod($trace, $expectedUrl, $expectedMethod)) {
+                    return false;
                 }
 
-                if (null === $trace['options']['body'] && null !== $trace['options']['json']) {
-                    $actualBody = $trace['options']['json']->getValue(true);
-                }
+                $options     = $trace['options'] ?? [];
+                $actualBody  = $this->extractValue($options['body'] ?? $options['json'] ?? null);
+                $bodyMatches = $expectedBody === null || $expectedBody === $actualBody;
 
-                if (!$actualBody) {
-                    continue;
-                }
+                $headersMatch = $expectedHeaders === [] || (
+                        is_array($headerValues = $this->extractValue($options['headers'] ?? []))
+                        && ($normalizedExpected = array_change_key_case($expectedHeaders))
+                        === array_intersect_key(array_change_key_case($headerValues), $normalizedExpected)
+                    );
 
-                if ($expectedBody === $actualBody) {
-                    $expectedRequestHasBeenFound = true;
+                return $bodyMatches && $headersMatch;
+            },
+        );
 
-                    if (!$expectedHeaders) {
-                        break;
-                    }
-                }
-            }
-
-            if ($expectedHeaders) {
-                $actualHeaders = $trace['options']['headers'] ?? [];
-
-                foreach ($actualHeaders as $headerKey => $actualHeader) {
-                    if (array_key_exists($headerKey, $expectedHeaders)
-                        && $expectedHeaders[$headerKey] === $actualHeader->getValue(true)
-                    ) {
-                        $expectedRequestHasBeenFound = true;
-                        break 2;
-                    }
-                }
-            }
-
-            $expectedRequestHasBeenFound = true;
-            break;
-        }
-
-        $this->assertTrue($expectedRequestHasBeenFound, 'The expected request has not been called: "' . $expectedMethod . '" - "' . $expectedUrl . '"');
+        $this->assertNotEmpty(
+            $matchingRequests,
+            sprintf('The expected request has not been called: "%s" - "%s"', $expectedMethod, $expectedUrl)
+        );
     }
 
     /**
-     * Asserts that the given number of requests has been made on the HttpClient.
-     * By default, it will check on the HttpClient, but you can also pass a specific HttpClient ID.
+     * Asserts that exactly $count requests have been executed by the given HttpClient.
+     * By default, it will inspect the default Symfony HttpClient; you may check a different one by passing its
+     * service-id in $httpClientId.
      *
      * ```php
-     * <?php
      * $I->assertHttpClientRequestCount(3);
      * ```
      */
     public function assertHttpClientRequestCount(int $count, string $httpClientId = 'http_client'): void
     {
-        $httpClientCollector = $this->grabHttpClientCollector(__FUNCTION__);
-
-        $this->assertCount($count, $httpClientCollector->getClients()[$httpClientId]['traces']);
+        $this->assertCount($count, $this->getHttpClientTraces($httpClientId, __FUNCTION__));
     }
 
     /**
-     * Asserts that the given URL has not been called using GET or the specified method.
-     * By default, it will check on the HttpClient, but a HttpClient id can be specified.
-     *
+     * Asserts that the given URL *has not* been requested with the supplied HTTP method.
+     * By default, it will inspect the default Symfony HttpClient; you may check a different one by passing its
+     * service-id in $httpClientId.
      * ```php
-     * <?php
      * $I->assertNotHttpClientRequest('https://example.com/unexpected', 'GET');
      * ```
      */
-    public function assertNotHttpClientRequest(string $unexpectedUrl, string $expectedMethod = 'GET', string $httpClientId = 'http_client'): void
-    {
-        $httpClientCollector = $this->grabHttpClientCollector(__FUNCTION__);
-        $unexpectedUrlHasBeenFound = false;
+    public function assertNotHttpClientRequest(
+        string $unexpectedUrl,
+        string $unexpectedMethod = 'GET',
+        string $httpClientId = 'http_client',
+    ): void {
+        $matchingRequests = array_filter(
+            $this->getHttpClientTraces($httpClientId, __FUNCTION__),
+            fn(array $trace): bool => $this->matchesUrlAndMethod($trace, $unexpectedUrl, $unexpectedMethod)
+        );
 
-        if (!array_key_exists($httpClientId, $httpClientCollector->getClients())) {
+        $this->assertEmpty(
+            $matchingRequests,
+            sprintf('Unexpected URL was called: "%s" - "%s"', $unexpectedMethod, $unexpectedUrl)
+        );
+    }
+
+    /**
+     * @return list<array{
+     *     info: array{url: string},
+     *     url: string,
+     *     method: string,
+     *     options?: array{body?: mixed, json?: mixed, headers?: mixed}
+     * }>
+     */
+    private function getHttpClientTraces(string $httpClientId, string $function): array
+    {
+        $httpClientCollector = $this->grabHttpClientCollector($function);
+
+        /** @var array<string, array{traces: list<array{
+         *     info: array{url: string},
+         *     url: string,
+         *     method: string,
+         *     options?: array{body?: mixed, json?: mixed, headers?: mixed}
+         * }>}> $clients
+         */
+        $clients = $httpClientCollector->getClients();
+
+        if (!array_key_exists($httpClientId, $clients)) {
             $this->fail(sprintf('HttpClient "%s" is not registered.', $httpClientId));
         }
 
-        foreach ($httpClientCollector->getClients()[$httpClientId]['traces'] as $trace) {
-            if (($unexpectedUrl === $trace['info']['url'] || $unexpectedUrl === $trace['url'])
-                && $expectedMethod === $trace['method']
-            ) {
-                $unexpectedUrlHasBeenFound = true;
-                break;
-            }
-        }
+        return $clients[$httpClientId]['traces'];
+    }
 
-        $this->assertFalse($unexpectedUrlHasBeenFound, sprintf('Unexpected URL called: "%s" - "%s"', $expectedMethod, $unexpectedUrl));
+    /** @param array{info: array{url: string}, url: string, method: string} $trace */
+    private function matchesUrlAndMethod(array $trace, string $expectedUrl, string $expectedMethod): bool
+    {
+        return in_array($expectedUrl, [$trace['info']['url'], $trace['url']], true)
+            && $expectedMethod === $trace['method'];
+    }
+
+    private function extractValue(mixed $value): mixed
+    {
+        return match (true) {
+            $value instanceof Data => $value->getValue(true),
+            is_object($value) && method_exists($value, 'getValue') => $value->getValue(true),
+            is_object($value) && method_exists($value, '__toString') => (string) $value,
+            default => $value,
+        };
     }
 
     protected function grabHttpClientCollector(string $function): HttpClientDataCollector

--- a/src/Codeception/Module/Symfony/LoggerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/LoggerAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Module\Symfony\DataCollectorName;
 use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
 use Symfony\Component\VarDumper\Cloner\Data;
 use function sprintf;
@@ -52,6 +53,6 @@ trait LoggerAssertionsTrait
 
     protected function grabLoggerCollector(string $function): LoggerDataCollector
     {
-        return $this->grabCollector('logger', $function);
+        return $this->grabCollector(DataCollectorName::LOGGER, $function);
     }
 }

--- a/src/Codeception/Module/Symfony/LoggerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/LoggerAssertionsTrait.php
@@ -23,33 +23,30 @@ trait LoggerAssertionsTrait
      */
     public function dontSeeDeprecations(string $message = ''): void
     {
-        $loggerCollector = $this->grabLoggerCollector(__FUNCTION__);
-        $logs = $loggerCollector->getProcessedLogs();
-
+        $logs = $this->grabLoggerCollector(__FUNCTION__)->getProcessedLogs();
         $foundDeprecations = [];
 
+        /** @var array<string, mixed> $log */
         foreach ($logs as $log) {
-            if (isset($log['type']) && $log['type'] === 'deprecation') {
-                $msg = $log['message'];
-                if ($msg instanceof Data) {
-                    $msg = $msg->getValue(true);
-                }
-                if (!is_string($msg)) {
-                    $msg = (string)$msg;
-                }
-                $foundDeprecations[] = $msg;
+            if (!isset($log['type']) || $log['type'] !== 'deprecation') {
+                continue;
             }
+            $msg = $log['message'];
+            if ($msg instanceof Data) {
+                $msg = $msg->getValue(true);
+            }
+            if (!is_string($msg) && !is_scalar($msg)) {
+                $msg = json_encode($msg, JSON_THROW_ON_ERROR);
+            }
+            $foundDeprecations[] = (string) $msg;
         }
-
+        $count = count($foundDeprecations);
         $errorMessage = $message ?: sprintf(
             "Found %d deprecation message%s in the log:\n%s",
-            count($foundDeprecations),
-            count($foundDeprecations) > 1 ? 's' : '',
-            implode("\n", array_map(static function ($msg) {
-                return "  - " . $msg;
-            }, $foundDeprecations))
+            $count,
+            $count !== 1 ? 's' : '',
+            implode("\n", array_map(static fn(string $m): string => "  - $m", $foundDeprecations)),
         );
-
         $this->assertEmpty($foundDeprecations, $errorMessage);
     }
 

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\Event\MessageEvents;
@@ -117,7 +118,7 @@ trait MailerAssertionsTrait
      * $emails = $I->grabSentEmails();
      * ```
      *
-     * @return \Symfony\Component\Mime\Email[]
+     * @return \Symfony\Component\Mime\RawMessage[]
      */
     public function grabSentEmails(): array
     {
@@ -163,14 +164,14 @@ trait MailerAssertionsTrait
 
     protected function getMessageMailerEvents(): MessageEvents
     {
-        if ($mailer = $this->getService('mailer.message_logger_listener')) {
-            /** @var MessageLoggerListener $mailer */
+        $mailer = $this->getService('mailer.message_logger_listener');
+        if ($mailer instanceof MessageLoggerListener) {
             return $mailer->getEvents();
         }
-        if ($mailer = $this->getService('mailer.logger_message_listener')) {
-            /** @var MessageLoggerListener $mailer */
+        $mailer = $this->getService('mailer.logger_message_listener');
+        if ($mailer instanceof MessageLoggerListener) {
             return $mailer->getEvents();
         }
-        $this->fail("Emails can't be tested without Symfony Mailer service.");
+        Assert::fail("Emails can't be tested without Symfony Mailer service.");
     }
 }

--- a/src/Codeception/Module/Symfony/ParameterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ParameterAssertionsTrait.php
@@ -17,6 +17,8 @@ trait ParameterAssertionsTrait
      * $I->grabParameter('app.business_name');
      * ```
      * This only works for explicitly set parameters (just using `bind` for Symfony's dependency injection is not enough).
+     *
+     * @return array<array-key, mixed>|bool|string|int|float|UnitEnum|null
      */
     public function grabParameter(string $parameterName): array|bool|string|int|float|UnitEnum|null
     {
@@ -26,6 +28,8 @@ trait ParameterAssertionsTrait
 
     protected function grabParameterBagService(): ParameterBagInterface
     {
-        return $this->grabService('parameter_bag');
+        /** @var ParameterBagInterface $parameterBag */
+        $parameterBag = $this->grabService(ParameterBagInterface::class);
+        return $parameterBag;
     }
 }

--- a/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use Symfony\Component\Routing\Exception\ResourceNotFoundException;
-use Symfony\Component\Routing\Route;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\Routing\RouterInterface;
+
 use function array_intersect_assoc;
-use function explode;
+use function is_string;
+use function parse_url;
 use function sprintf;
+use function str_ends_with;
 
 trait RouterAssertionsTrait
 {
@@ -22,25 +24,12 @@ trait RouterAssertionsTrait
      * $I->amOnAction('HomeController');
      * $I->amOnAction('ArticleController', ['slug' => 'lorem-ipsum']);
      * ```
+     *
+     * @param array<string, mixed> $params
      */
     public function amOnAction(string $action, array $params = []): void
     {
-        $router = $this->grabRouterService();
-        $routes = $router->getRouteCollection()->getIterator();
-
-        /** @var Route $route */
-        foreach ($routes as $route) {
-            $controller = $route->getDefault('_controller');
-            if (str_ends_with((string) $controller, $action)) {
-                $resource = $router->match($route->getPath());
-                $url      = $router->generate(
-                    $resource['_route'],
-                    $params
-                );
-                $this->amOnPage($url);
-                return;
-            }
-        }
+        $this->openRoute($this->findRouteByActionOrFail($action), $params);
     }
 
     /**
@@ -51,16 +40,13 @@ trait RouterAssertionsTrait
      * $I->amOnRoute('posts.create');
      * $I->amOnRoute('posts.show', ['id' => 34]);
      * ```
+     *
+     * @param array<string, mixed> $params
      */
     public function amOnRoute(string $routeName, array $params = []): void
     {
-        $router = $this->grabRouterService();
-        if ($router->getRouteCollection()->get($routeName) === null) {
-            $this->fail(sprintf('Route with name "%s" does not exist.', $routeName));
-        }
-
-        $url = $router->generate($routeName, $params);
-        $this->amOnPage($url);
+        $this->assertRouteExists($routeName);
+        $this->openRoute($routeName, $params);
     }
 
     /**
@@ -82,22 +68,11 @@ trait RouterAssertionsTrait
      */
     public function seeCurrentActionIs(string $action): void
     {
-        $router = $this->grabRouterService();
-        $routes = $router->getRouteCollection()->getIterator();
+        $this->findRouteByActionOrFail($action);
 
-        /** @var Route $route */
-        foreach ($routes as $route) {
-            $controller = $route->getDefault('_controller');
-            if (str_ends_with((string) $controller, $action)) {
-                $request = $this->getClient()->getRequest();
-                $currentActionFqcn = $request->attributes->get('_controller');
-
-                $this->assertStringEndsWith($action, $currentActionFqcn, "Current action is '{$currentActionFqcn}'.");
-                return;
-            }
-        }
-
-        $this->fail("Action '{$action}' does not exist");
+        /** @var string $current */
+        $current = $this->getClient()->getRequest()->attributes->get('_controller');
+        $this->assertStringEndsWith($action, $current, "Current action is '{$current}'.");
     }
 
     /**
@@ -108,32 +83,19 @@ trait RouterAssertionsTrait
      * $I->seeCurrentRouteIs('posts.index');
      * $I->seeCurrentRouteIs('posts.show', ['id' => 8]);
      * ```
+     *
+     * @param array<string, mixed> $params
      */
     public function seeCurrentRouteIs(string $routeName, array $params = []): void
     {
-        $router = $this->grabRouterService();
-        if ($router->getRouteCollection()->get($routeName) === null) {
-            $this->fail(sprintf('Route with name "%s" does not exist.', $routeName));
-        }
-
-        $uri = explode('?', $this->grabFromCurrentUrl())[0];
-        $uri = explode('#', $uri)[0];
-        $match = [];
-        try {
-            $match = $router->match($uri);
-        } catch (ResourceNotFoundException) {
-            $this->fail(sprintf('The "%s" url does not match with any route', $uri));
-        }
-
-        $expected = ['_route' => $routeName, ...$params];
-        $intersection = array_intersect_assoc($expected, $match);
-
-        $this->assertSame($expected, $intersection);
+        $match    = $this->getCurrentRouteMatch($routeName);
+        $expected = ['_route' => $routeName] + $params;
+        $this->assertSame($expected, array_intersect_assoc($expected, $match));
     }
 
     /**
      * Checks that current url matches route.
-     * Unlike seeCurrentRouteIs, this can matches without exact route parameters
+     * Unlike seeCurrentRouteIs, this can match without exact route parameters
      *
      * ```php
      * <?php
@@ -142,25 +104,52 @@ trait RouterAssertionsTrait
      */
     public function seeInCurrentRoute(string $routeName): void
     {
-        $router = $this->grabRouterService();
-        if ($router->getRouteCollection()->get($routeName) === null) {
-            $this->fail(sprintf('Route with name "%s" does not exist.', $routeName));
-        }
+        $this->assertSame($routeName, $this->getCurrentRouteMatch($routeName)['_route']);
+    }
 
-        $uri = explode('?', $this->grabFromCurrentUrl())[0];
-        $uri = explode('#', $uri)[0];
-        $matchedRouteName = '';
-        try {
-            $matchedRouteName = (string)$router->match($uri)['_route'];
-        } catch (ResourceNotFoundException) {
-            $this->fail(sprintf('The "%s" url does not match with any route', $uri));
-        }
+    /** @return array<string, mixed> */
+    private function getCurrentRouteMatch(string $routeName): array
+    {
+        $this->assertRouteExists($routeName);
 
-        $this->assertSame($matchedRouteName, $routeName);
+        $url  = $this->grabFromCurrentUrl();
+        Assert::assertIsString($url, 'Unable to obtain current URL.');
+        $path = (string) parse_url($url, PHP_URL_PATH);
+
+        /** @var array<string, mixed> $match */
+        $match = $this->grabRouterService()->match($path);
+        return $match;
+    }
+
+    private function findRouteByActionOrFail(string $action): string
+    {
+        foreach ($this->grabRouterService()->getRouteCollection()->all() as $name => $route) {
+            $ctrl = $route->getDefault('_controller');
+            if (is_string($ctrl) && str_ends_with($ctrl, $action)) {
+                return $name;
+            }
+        }
+        Assert::fail(sprintf("Action '%s' does not exist.", $action));
+    }
+
+    private function assertRouteExists(string $routeName): void
+    {
+        $this->assertNotNull(
+            $this->grabRouterService()->getRouteCollection()->get($routeName),
+            sprintf('Route "%s" does not exist.', $routeName)
+        );
+    }
+
+    /** @param array<string, mixed> $params */
+    private function openRoute(string $routeName, array $params = []): void
+    {
+        $this->amOnPage($this->grabRouterService()->generate($routeName, $params));
     }
 
     protected function grabRouterService(): RouterInterface
     {
-        return $this->grabService('router');
+        /** @var RouterInterface $router */
+        $router = $this->grabService('router');
+        return $router;
     }
 }

--- a/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
@@ -25,10 +25,12 @@ trait ServicesAssertionsTrait
     public function grabService(string $serviceId): object
     {
         if (!$service = $this->getService($serviceId)) {
-            Assert::fail("Service `{$serviceId}` is required by Codeception, but not loaded by Symfony. Possible solutions:\n
+            Assert::fail(
+                "Service `{$serviceId}` is required by Codeception, but not loaded by Symfony. Possible solutions:\n
             In your `config/packages/framework.php`/`.yaml`, set `test` to `true` (when in test environment), see https://symfony.com/doc/current/reference/configuration/framework.html#test\n
             If you're still getting this message, you're not using that service in your app, so Symfony isn't loading it at all.\n
-            Solution: Set it to `public` in your `config/services.php`/`.yaml`, see https://symfony.com/doc/current/service_container/alias_private.html#marking-services-as-public-private\n");
+            Solution: Set it to `public` in your `config/services.php`/`.yaml`, see https://symfony.com/doc/current/service_container/alias_private.html#marking-services-as-public-private\n"
+            );
         }
 
         return $service;

--- a/src/Codeception/Module/Symfony/TimeAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/TimeAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Module\Symfony\DataCollectorName;
 use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
 use function round;
 use function sprintf;
@@ -45,6 +46,6 @@ trait TimeAssertionsTrait
 
     protected function grabTimeCollector(string $function): TimeDataCollector
     {
-        return $this->grabCollector('time', $function);
+        return $this->grabCollector(DataCollectorName::TIME, $function);
     }
 }

--- a/src/Codeception/Module/Symfony/TranslationAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/TranslationAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Module\Symfony\DataCollectorName;
 use Symfony\Component\Translation\DataCollector\TranslationDataCollector;
 use Symfony\Component\VarDumper\Cloner\Data;
 
@@ -173,6 +174,6 @@ trait TranslationAssertionsTrait
 
     protected function grabTranslationCollector(string $function): TranslationDataCollector
     {
-        return $this->grabCollector('translation', $function);
+        return $this->grabCollector(DataCollectorName::TRANSLATION, $function);
     }
 }

--- a/src/Codeception/Module/Symfony/TwigAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/TwigAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Module\Symfony\DataCollectorName;
 use Symfony\Bridge\Twig\DataCollector\TwigDataCollector;
 use function array_key_first;
 
@@ -77,6 +78,6 @@ trait TwigAssertionsTrait
 
     protected function grabTwigCollector(string $function): TwigDataCollector
     {
-        return $this->grabCollector('twig', $function);
+        return $this->grabCollector(DataCollectorName::TWIG, $function);
     }
 }

--- a/src/Codeception/Module/Symfony/TwigAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/TwigAssertionsTrait.php
@@ -43,7 +43,7 @@ trait TwigAssertionsTrait
         $twigCollector = $this->grabTwigCollector(__FUNCTION__);
 
         $templates = $twigCollector->getTemplates();
-        $actualTemplate = empty($templates) ? 'N/A' : (string) array_key_first($templates);
+        $actualTemplate = $templates === [] ? 'N/A' : (string) array_key_first($templates);
 
         $this->assertSame(
             $expectedTemplate,

--- a/src/Codeception/Module/Symfony/ValidatorAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ValidatorAssertionsTrait.php
@@ -101,6 +101,8 @@ trait ValidatorAssertionsTrait
 
     protected function getValidatorService(): ValidatorInterface
     {
-        return $this->grabService(ValidatorInterface::class);
+        /** @var ValidatorInterface $validator */
+        $validator = $this->grabService(ValidatorInterface::class);
+        return $validator;
     }
 }


### PR DESCRIPTION
## Summary
- introduce DataCollectorName enum to centralize Symfony profiler collector names and types
- apply DataCollectorName across module and assertion traits for type safety
- remove broad exception catch when loading the profiler

## Testing
- `vendor/bin/phpstan analyse src/Codeception/Module/Symfony/DataCollectorName.php --level=max --no-progress`
- `vendor/bin/phpstan analyse src/Codeception/Module/Symfony.php --level=max --no-progress --memory-limit=1G`
- `vendor/bin/phpstan analyse src/Codeception/Module/Symfony/TimeAssertionsTrait.php --level=max --no-progress`
- `vendor/bin/phpstan analyse src/Codeception/Module/Symfony/TranslationAssertionsTrait.php --level=max --no-progress`
- `vendor/bin/phpstan analyse src/Codeception/Module/Symfony/EventsAssertionsTrait.php --level=max --no-progress`
- `vendor/bin/phpstan analyse src/Codeception/Module/Symfony/LoggerAssertionsTrait.php --level=max --no-progress`
- `vendor/bin/phpstan analyse src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php --level=max --no-progress`
- `vendor/bin/phpstan analyse src/Codeception/Module/Symfony/FormAssertionsTrait.php --level=max --no-progress`
- `vendor/bin/phpstan analyse src/Codeception/Module/Symfony/TwigAssertionsTrait.php --level=max --no-progress`
- `vendor/bin/phpstan clear-result-cache`
- `vendor/bin/phpstan analyse src --level=max --no-progress --memory-limit=1G`


------
https://chatgpt.com/codex/tasks/task_e_688f77a6c054832cb8a5b38e1f2f8ea8