### PR TITLE
Simplify grabCachedService in CacheTrait

### DIFF
--- a/src/Codeception/Module/Symfony/CacheTrait.php
+++ b/src/Codeception/Module/Symfony/CacheTrait.php
@@ -17,11 +17,7 @@ trait CacheTrait
     private ?WeakMap $profileCache = null;
 
     /**
-     * @var array{
-     *     internalDomains?: list<non-empty-string>,
-     *     messageLoggerServiceId?: ?string,
-     *     notifierLoggerServiceId?: ?string
-     * }
+     * @var array<string, mixed>
      */
     protected array $state = [];
 
@@ -50,7 +46,10 @@ trait CacheTrait
     protected function getInternalDomains(): array
     {
         if (isset($this->state['internalDomains'])) {
-            return $this->state['internalDomains'];
+            /** @var list<non-empty-string> $domains */
+            $domains = $this->state['internalDomains'];
+
+            return $domains;
         }
 
         $domains = [];
@@ -73,19 +72,20 @@ trait CacheTrait
 
     /**
      * @template T of object
-     * @param 'messageLoggerServiceId'|'notifierLoggerServiceId' $key
-     * @param string[] $serviceIds
      * @param class-string<T> $expectedClass
+     * @param string[] $serviceIds
      * @return T|null
      */
-    protected function grabCachedService(string $key, array $serviceIds, string $expectedClass): ?object
+    protected function grabCachedService(string $expectedClass, array $serviceIds): ?object
     {
-        $serviceId = $this->state[$key] ??= (function () use ($serviceIds, $expectedClass): ?string {
+        /** @var ?string $serviceId */
+        $serviceId = $this->state[$expectedClass] ??= (function () use ($serviceIds, $expectedClass): ?string {
             foreach ($serviceIds as $id) {
                 if ($this->getService($id) instanceof $expectedClass) {
                     return $id;
                 }
             }
+
             return null;
         })();
 
@@ -94,10 +94,7 @@ trait CacheTrait
         }
 
         $service = $this->getService($serviceId);
-        if ($service instanceof $expectedClass) {
-            return $service;
-        }
 
-        return null;
+        return $service instanceof $expectedClass ? $service : null;
     }
 }

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -164,9 +164,8 @@ trait MailerAssertionsTrait
     protected function getMessageMailerEvents(): MessageEvents
     {
         $logger = $this->grabCachedService(
-            'messageLoggerServiceId',
-            ['mailer.message_logger_listener', 'mailer.logger_message_listener'],
-            MessageLoggerListener::class
+            MessageLoggerListener::class,
+            ['mailer.message_logger_listener', 'mailer.logger_message_listener']
         );
 
         if ($logger !== null) {

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -261,9 +261,8 @@ trait NotifierAssertionsTrait
     private function getNotifierLoggerListener(): ?NotificationLoggerListener
     {
         return $this->grabCachedService(
-            'notifierLoggerServiceId',
-            ['notifier.notification_logger_listener', 'notifier.logger_notification_listener'],
-            NotificationLoggerListener::class
+            NotificationLoggerListener::class,
+            ['notifier.notification_logger_listener', 'notifier.logger_notification_listener']
         );
     }
 }


### PR DESCRIPTION
Simplified the caching mechanism in CacheTrait by utilizing the expected class name directly as the cache state key, thereby removing the need for a separate string key parameter in `grabCachedService()`. Updated the assertions traits to adopt the simpler API.

---
*PR created automatically by Jules for task [3471595075108574764](https://jules.google.com/task/3471595075108574764) started by @TavoNiievez*