### PR TITLE
Fix PHPStan redundant null coalescing errors in SessionAssertionsTrait

### DIFF
--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -199,13 +199,13 @@ trait SessionAssertionsTrait
     {
         $roles = $user->getRoles();
 
-        if ($this->getSymfonyMajorVersion() >= 6 && ($this->config['authenticator'] ?? false) === true) {
+        if ($this->getSymfonyMajorVersion() >= 6 && $this->config['authenticator'] === true) {
             /** @var AuthenticatorInterface $authenticator */
             $authenticator = $this->grabService(AuthenticatorInterface::class);
             return $authenticator->createToken(new SelfValidatingPassport(new UserBadge($user->getUserIdentifier(), static fn() => $user)), $firewallName);
         }
 
-        if ($this->getSymfonyMajorVersion() < 6 && ($this->config['guard'] ?? false) === true) {
+        if ($this->getSymfonyMajorVersion() < 6 && $this->config['guard'] === true) {
             $postClass = 'Symfony\\Component\\Security\\Guard\\Token\\PostAuthenticationGuardToken';
             if (class_exists($postClass)) {
                 /** @var TokenInterface */


### PR DESCRIPTION
Removed `?? false` checks for `$this->config['authenticator']` and `$this->config['guard']` in `SessionAssertionsTrait`. These keys are defined in the `$config` array shape as boolean and always exist with boolean defaults, making the null coalescing operator redundant and incorrectly typed according to strict PHPStan analysis.

---
*PR created automatically by Jules for task [2504932045769262313](https://jules.google.com/task/2504932045769262313) started by @TavoNiievez*