### PR TITLE
🎨 Palette (DX): Refactor HttpClientAssertionsTrait to use Stringable interface

### DIFF
--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -152,7 +152,7 @@ trait HttpClientAssertionsTrait
         return match (true) {
             $value instanceof Data => $value->getValue(true),
             is_object($value) && method_exists($value, 'getValue') => $value->getValue(true),
-            is_object($value) && method_exists($value, '__toString') => (string) $value,
+            $value instanceof \Stringable => (string) $value,
             default => $value,
         };
     }


### PR DESCRIPTION
🎨 Palette (DX): Refactor HttpClientAssertionsTrait to use Stringable interface

💡 What: Refactored `extractValue()` in `HttpClientAssertionsTrait` to use the modern PHP `\Stringable` interface instead of duck-typing `method_exists($value, '__toString')`.
🎯 Why: This micro-DX improvement makes the code more self-documenting, improves IDE type inference, reduces cognitive load, and aligns with modern PHP 8+ standards.
🛠️ Tooling: Improves static analysis by using a built-in interface rather than relying on runtime method existence checks.

---
*PR created automatically by Jules for task [18267655487948727958](https://jules.google.com/task/18267655487948727958) started by @TavoNiievez*