### PR TITLE
🎨 Palette (DX): Add return type to grabSecurityService

### DIFF
--- a/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
@@ -142,8 +142,7 @@ trait SecurityAssertionsTrait
             && $this->grabSecurityService()->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED);
     }
 
-    /** @return Security */
-    protected function grabSecurityService()
+    protected function grabSecurityService(): Security
     {
         /** @var Security */
         return $this->grabService('security.helper');


### PR DESCRIPTION
💡 What: Added `: Security` return type hint to `grabSecurityService()`.
🎯 Why: Ensures strict typing, reduces cognitive load by clearly defining the return type without needing to read docblocks, and prevents potential runtime errors by letting PHP enforce the return type.
🛠️ Tooling: Improves IDE "Go to Definition" and Autocomplete, and provides better static analysis support for PHPStan.

---
*PR created automatically by Jules for task [3090374260806313097](https://jules.google.com/task/3090374260806313097) started by @TavoNiievez*