### PR TITLE
🎨 Palette (DX): Strict return type for grabSecurityService

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Return Types for Internal Helpers]
+**Learning:** Legacy traits often rely on `@return` PHPDoc annotations instead of strict PHP return types, which reduces IDE autocompletion confidence and type safety.
+**Action:** When finding methods with only `@return` hints (especially for classes like `Security`), enforce native strict return types (e.g. `grabSecurityService(): Security`) to let PHP and the IDE enforce guarantees without manual tracking.

--- a/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
@@ -142,8 +142,7 @@ trait SecurityAssertionsTrait
             && $this->grabSecurityService()->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED);
     }
 
-    /** @return Security */
-    protected function grabSecurityService()
+    protected function grabSecurityService(): Security
     {
         /** @var Security */
         return $this->grabService('security.helper');


### PR DESCRIPTION
💡 What: Converted the legacy `@return Security` PHPDoc annotation to a strict PHP native `: Security` return type in `SecurityAssertionsTrait::grabSecurityService`.

🎯 Why: It reduces cognitive load by letting the PHP engine and IDE enforce type guarantees without humans having to trace the `$this->grabService()` container return type manually. This removes "mystery meat" return objects from internal helpers, strictly enforcing type safety.

🛠️ Tooling: Improved IDE autocomplete and PHPStan static analysis confidence by providing an iron-clad runtime return type instead of an easily-ignored docblock. Added journal entry to `.jules/palette_dx.md`.

---
*PR created automatically by Jules for task [13579924540012278839](https://jules.google.com/task/13579924540012278839) started by @TavoNiievez*