### PR TITLE
🎨 Palette (DX): Use Stringable interface in HttpClientAssertionsTrait

### DIFF
--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codeception\Module\Symfony;
 
 use PHPUnit\Framework\Assert;
+use Stringable;
 use Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector;
 use Symfony\Component\VarDumper\Cloner\Data;
 
@@ -149,7 +150,7 @@ trait HttpClientAssertionsTrait
         return match (true) {
             $value instanceof Data => $value->getValue(true),
             is_object($value) && method_exists($value, 'getValue') => $value->getValue(true),
-            $value instanceof \Stringable => (string) $value,
+            $value instanceof Stringable => (string) $value,
             default => $value,
         };
     }

--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -149,7 +149,7 @@ trait HttpClientAssertionsTrait
         return match (true) {
             $value instanceof Data => $value->getValue(true),
             is_object($value) && method_exists($value, 'getValue') => $value->getValue(true),
-            is_object($value) && method_exists($value, '__toString') => (string) $value,
+            $value instanceof \Stringable => (string) $value,
             default => $value,
         };
     }


### PR DESCRIPTION
💡 What: Replaced the combination of `is_object($value)` and `method_exists($value, '__toString')` with a direct `$value instanceof \Stringable` check in the `extractValue` method.

🎯 Why: In PHP 8.0+, any class that implements `__toString()` implicitly implements the `\Stringable` interface. This change leverages a modern PHP 8.0+ native interface, making the code much more concise, idiomatic, and readable, thus reducing cognitive load for developers reading or maintaining this HTTP trace extraction logic.

🛠️ Tooling: Improves static analysis understanding (PHPStan natively recognizes `\Stringable` for string casting) and ensures cleaner type-safe evaluation during code execution.

---
*PR created automatically by Jules for task [6061309878603464257](https://jules.google.com/task/6061309878603464257) started by @TavoNiievez*