### PR TITLE
🎨 Palette (DX): Replace version_compare with class_exists

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2025-02-15 - Remove @phpstan-ignore with class_exists
+**Learning:** Checking `Kernel::VERSION` for component availability triggers PHPStan errors because the version constant is fixed at analysis time.
+**Action:** Use `class_exists()` or `interface_exists()` for optional components to ensure static analysis correctly infers code reachability without `@phpstan-ignore`.

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -14,7 +14,7 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Test\Constraint as NotifierConstraint;
 
 use function array_key_last;
-use function version_compare;
+use function class_exists;
 
 trait NotifierAssertionsTrait
 {
@@ -243,8 +243,7 @@ trait NotifierAssertionsTrait
 
     protected function getNotificationEvents(): NotificationEvents
     {
-        // @phpstan-ignore if.alwaysFalse
-        if (version_compare(Kernel::VERSION, '6.2', '<')) {
+        if (!class_exists(NotificationEvents::class)) {
             Assert::fail('Notifier assertions require Symfony 6.2 or higher.');
         }
 

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -14,7 +14,7 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Test\Constraint as NotifierConstraint;
 
 use function array_key_last;
-use function class_exists;
+use function version_compare;
 
 trait NotifierAssertionsTrait
 {


### PR DESCRIPTION
💡 What: Replaced `version_compare(Kernel::VERSION, '6.2', '<')` with `!class_exists(NotificationEvents::class)` in `NotifierAssertionsTrait`. This completely eliminated the need for the `@phpstan-ignore if.alwaysFalse` comment.

🎯 Why: `Kernel::VERSION` is evaluated as a string constant by PHPStan, resulting in always-false evaluations that required explicit suppression (`@phpstan-ignore`). Checking for the component class using `class_exists()` enables PHPStan to natively infer reachability. This adheres to the rule that code logic should naturally satisfy static analysis rather than bypassing it.

🛠️ Tooling: Enhances PHPStan analysis robustness. No regressions were introduced; all tests pass on Level Max.

---
*PR created automatically by Jules for task [17948842828635197548](https://jules.google.com/task/17948842828635197548) started by @TavoNiievez*