### PR TITLE
🎨 Palette (DX): Add native return type to grabSecurityService

### DIFF
--- a/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
@@ -142,8 +142,7 @@ trait SecurityAssertionsTrait
             && $this->grabSecurityService()->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED);
     }
 
-    /** @return Security */
-    protected function grabSecurityService()
+    protected function grabSecurityService(): Security
     {
         /** @var Security */
         return $this->grabService('security.helper');


### PR DESCRIPTION
💡 What: Removed redundant docblock return type `@return Security` in favor of native PHP return type hint `: Security` for `grabSecurityService`.

🎯 Why: Native return types improve discoverability and type-safety, letting the IDE and PHPStan catch bugs so humans don't have to. It reduces cognitive load because a developer inherently knows what a method returns without relying strictly on docblocks which can sometimes become stale.

🛠️ Tooling: Improves PHPStan and IDE (LSP) support by enforcing strict typing natively.

---
*PR created automatically by Jules for task [6632347549078716743](https://jules.google.com/task/6632347549078716743) started by @TavoNiievez*