### PR TITLE
⚡ Bolt: Optimize session cookie lookup

### DIFF
--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -20,7 +20,6 @@ use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
 use function class_exists;
 use function get_debug_type;
-use function in_array;
 use function is_int;
 use function is_string;
 use function serialize;
@@ -125,8 +124,9 @@ trait SessionAssertionsTrait
 
         $cookieJar = $this->getClient()->getCookieJar();
         foreach ($cookieJar->all() as $cookie) {
-            if (in_array($cookie->getName(), ['MOCKSESSID', 'REMEMBERME', $sessionName], true)) {
-                $cookieJar->expire($cookie->getName());
+            $cookieName = $cookie->getName();
+            if ($cookieName === 'MOCKSESSID' || $cookieName === 'REMEMBERME' || $cookieName === $sessionName) {
+                $cookieJar->expire($cookieName);
             }
         }
         $cookieJar->flushExpiredCookies();


### PR DESCRIPTION
💡 What: Extracted `$cookie->getName()` into a variable and replaced `in_array` with direct strict equality checks in the cookie iteration loop within `SessionAssertionsTrait::logoutProgrammatically()`.
🎯 Why: Prevents repeated dynamic array allocation (`['MOCKSESSID', 'REMEMBERME', $sessionName]`) and O(N) array searching inside the `foreach` loop.
📊 Impact: Minor speedup and lower memory allocation for sessions testing when traversing large cookie jars, removing an unnecessary O(N) lookup.
🔬 Measurement: Verify with `vendor/bin/phpunit tests/SessionAssertionsTest.php` to ensure correct behavior.

---
*PR created automatically by Jules for task [11904634625842970375](https://jules.google.com/task/11904634625842970375) started by @TavoNiievez*