### PR TITLE
🎨 Palette (DX): Use DataCollectorName enum for debugCollector

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -389,10 +389,10 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             return;
         }
 
-        $this->debugCollector($profile, DataCollectorName::SECURITY->value);
-        $this->debugCollector($profile, DataCollectorName::MAILER->value);
-        $this->debugCollector($profile, DataCollectorName::NOTIFIER->value);
-        $this->debugCollector($profile, DataCollectorName::TIME->value);
+        $this->debugCollector($profile, DataCollectorName::SECURITY);
+        $this->debugCollector($profile, DataCollectorName::MAILER);
+        $this->debugCollector($profile, DataCollectorName::NOTIFIER);
+        $this->debugCollector($profile, DataCollectorName::TIME);
     }
 
     protected function doRebootClientKernel(): void
@@ -463,13 +463,13 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $this->debugSection('Time', sprintf('%.2f ms', $timeCollector->getDuration()));
     }
 
-    private function debugCollector(Profile $profile, string $name): void
+    private function debugCollector(Profile $profile, DataCollectorName $name): void
     {
-        if (!$profile->hasCollector($name)) {
+        if (!$profile->hasCollector($name->value)) {
             return;
         }
 
-        $collector = $profile->getCollector($name);
+        $collector = $profile->getCollector($name->value);
         match (true) {
             $collector instanceof SecurityDataCollector => $this->debugSecurityData($collector),
             $collector instanceof MessageDataCollector => $this->debugMailerData($collector),


### PR DESCRIPTION
💡 What: Updated the `debugCollector` method signature in `src/Codeception/Module/Symfony.php` to accept a `DataCollectorName` Enum instead of a primitive `string`.

🎯 Why: This change enforces strict type safety and guarantees that only valid data collector names defined in the enum can be passed to the `debugCollector` method. It eliminates "mystery meat" string parameters, significantly improving code discoverability and reducing cognitive load for developers by making the expected input explicitly clear.

🛠️ Tooling: Improves IDE autocompletion (Go to Definition, parameter hints) and ensures PHPStan can natively infer code reachability for debug collector parameters.

---
*PR created automatically by Jules for task [6792660431291818565](https://jules.google.com/task/6792660431291818565) started by @TavoNiievez*