### PR TITLE
⚡ Bolt: [performance improvement] optimize logoutProgrammatically cookie check

### DIFF
--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -20,7 +20,6 @@ use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
 use function class_exists;
 use function get_debug_type;
-use function in_array;
 use function is_int;
 use function is_string;
 use function serialize;
@@ -125,8 +124,9 @@ trait SessionAssertionsTrait
 
         $cookieJar = $this->getClient()->getCookieJar();
         foreach ($cookieJar->all() as $cookie) {
-            if (in_array($cookie->getName(), ['MOCKSESSID', 'REMEMBERME', $sessionName], true)) {
-                $cookieJar->expire($cookie->getName());
+            $cookieName = $cookie->getName();
+            if ($cookieName === 'MOCKSESSID' || $cookieName === 'REMEMBERME' || $cookieName === $sessionName) {
+                $cookieJar->expire($cookieName);
             }
         }
         $cookieJar->flushExpiredCookies();


### PR DESCRIPTION
💡 What: Replaced the dynamic array creation and `in_array()` check with a chained strict equality (`===`) check in `SessionAssertionsTrait::logoutProgrammatically()`, and removed the unused `in_array` import.
🎯 Why: Inside the `foreach` loop iterating over cookies, dynamically constructing an array `['MOCKSESSID', 'REMEMBERME', $sessionName]` and calling `in_array` for every single cookie creates unnecessary memory allocations and O(N) lookup overhead.
📊 Impact: Reduces array instantiations inside the loop from O(N) to 0, completely avoiding the overhead of function calls (`in_array`) in favor of native strict boolean comparisons.
🔬 Measurement: Verified by `vendor/bin/phpunit tests/SessionAssertionsTest.php` and full test suite passing with no regressions.

---
*PR created automatically by Jules for task [2822235407637986809](https://jules.google.com/task/2822235407637986809) started by @TavoNiievez*