### PR TITLE
🎨 Palette (DX): Use Enum for debugCollector

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,5 @@
+# Palette DX Journal
+
+## 2024-04-08 - [Init]
+**Learning:** Initializing the journal for critical DX learnings.
+**Action:** Use this file to record significant DX insights or constraints encountered during improvements.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -389,10 +389,10 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             return;
         }
 
-        $this->debugCollector($profile, DataCollectorName::SECURITY->value);
-        $this->debugCollector($profile, DataCollectorName::MAILER->value);
-        $this->debugCollector($profile, DataCollectorName::NOTIFIER->value);
-        $this->debugCollector($profile, DataCollectorName::TIME->value);
+        $this->debugCollector($profile, DataCollectorName::SECURITY);
+        $this->debugCollector($profile, DataCollectorName::MAILER);
+        $this->debugCollector($profile, DataCollectorName::NOTIFIER);
+        $this->debugCollector($profile, DataCollectorName::TIME);
     }
 
     protected function doRebootClientKernel(): void
@@ -463,13 +463,13 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $this->debugSection('Time', sprintf('%.2f ms', $timeCollector->getDuration()));
     }
 
-    private function debugCollector(Profile $profile, string $name): void
+    private function debugCollector(Profile $profile, DataCollectorName $name): void
     {
-        if (!$profile->hasCollector($name)) {
+        if (!$profile->hasCollector($name->value)) {
             return;
         }
 
-        $collector = $profile->getCollector($name);
+        $collector = $profile->getCollector($name->value);
         match (true) {
             $collector instanceof SecurityDataCollector => $this->debugSecurityData($collector),
             $collector instanceof MessageDataCollector => $this->debugMailerData($collector),


### PR DESCRIPTION
💡 What: Refactored the `debugCollector` method in `src/Codeception/Module/Symfony.php` to accept a strictly typed `DataCollectorName` enum instead of a generic `string` parameter.

🎯 Why: This micro-DX improvement enforces valid inputs at the type level, preventing potential bugs caused by passing arbitrary or incorrect strings. It reduces cognitive load for developers by making the expected input explicitly clear and self-documenting.

🛠️ Tooling: This change immediately improves IDE autocompletion and static analysis by ensuring that only predefined data collector names are passed, which helps catch errors during development.

---
*PR created automatically by Jules for task [5904839576630126280](https://jules.google.com/task/5904839576630126280) started by @TavoNiievez*