### PR TITLE
🎨 Palette (DX): Enforce type safety for debugCollector parameter

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Enforce type safety for debugging data collectors]
+**Learning:** The `debugCollector` method was previously accepting primitive strings, leading to potential typos and missing IDE autocompletion.
+**Action:** Replaced the primitive string parameter with the `DataCollectorName` Enum to enforce type safety, improve DX, and rely on PHPStan/IDE for validation.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -389,10 +389,10 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             return;
         }
 
-        $this->debugCollector($profile, DataCollectorName::SECURITY->value);
-        $this->debugCollector($profile, DataCollectorName::MAILER->value);
-        $this->debugCollector($profile, DataCollectorName::NOTIFIER->value);
-        $this->debugCollector($profile, DataCollectorName::TIME->value);
+        $this->debugCollector($profile, DataCollectorName::SECURITY);
+        $this->debugCollector($profile, DataCollectorName::MAILER);
+        $this->debugCollector($profile, DataCollectorName::NOTIFIER);
+        $this->debugCollector($profile, DataCollectorName::TIME);
     }
 
     protected function doRebootClientKernel(): void
@@ -463,13 +463,13 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $this->debugSection('Time', sprintf('%.2f ms', $timeCollector->getDuration()));
     }
 
-    private function debugCollector(Profile $profile, string $name): void
+    private function debugCollector(Profile $profile, DataCollectorName $name): void
     {
-        if (!$profile->hasCollector($name)) {
+        if (!$profile->hasCollector($name->value)) {
             return;
         }
 
-        $collector = $profile->getCollector($name);
+        $collector = $profile->getCollector($name->value);
         match (true) {
             $collector instanceof SecurityDataCollector => $this->debugSecurityData($collector),
             $collector instanceof MessageDataCollector => $this->debugMailerData($collector),


### PR DESCRIPTION
💡 What: Updated `debugCollector` method to accept a `DataCollectorName` enum instead of a primitive string, using its value internally.
🎯 Why: Reduces cognitive load and prevents bugs by using PHP's type system to strictly define the allowed inputs. Also improves IDE autocompletion for callers.
🛠️ Tooling: Improves PHPStan analysis by strictly bounding parameter types.

Ensured strict types and 0 PHPStan errors. Validated with `vendor/bin/phpunit`.

---
*PR created automatically by Jules for task [13126372500668111293](https://jules.google.com/task/13126372500668111293) started by @TavoNiievez*