### PR TITLE
⚡ Bolt: [performance improvement] O(1) condition checks over in_array in SessionAssertionsTrait

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-09 - O(1) Condition Checks instead of in_array() overhead
+**Learning:** In heavily repeated loops, constructing small arrays (e.g., `['MOCKSESSID', 'REMEMBERME', $sessionName]`) just to check if a value exists via `in_array()` creates unnecessary memory allocation and lookup overhead. Direct O(1) `===` checks avoid this.
+**Action:** Use strict equality combined with logical OR (`||`) for small sets of static value checks instead of `in_array()` with on-the-fly arrays.

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -20,7 +20,6 @@ use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
 use function class_exists;
 use function get_debug_type;
-use function in_array;
 use function is_int;
 use function is_string;
 use function serialize;
@@ -125,8 +124,9 @@ trait SessionAssertionsTrait
 
         $cookieJar = $this->getClient()->getCookieJar();
         foreach ($cookieJar->all() as $cookie) {
-            if (in_array($cookie->getName(), ['MOCKSESSID', 'REMEMBERME', $sessionName], true)) {
-                $cookieJar->expire($cookie->getName());
+            $cookieName = $cookie->getName();
+            if ($cookieName === 'MOCKSESSID' || $cookieName === 'REMEMBERME' || $cookieName === $sessionName) {
+                $cookieJar->expire($cookieName);
             }
         }
         $cookieJar->flushExpiredCookies();


### PR DESCRIPTION
💡 What: Replaced a dynamic `in_array()` check with strict equality (`===`) and logical OR (`||`) within the cookie processing loop in `SessionAssertionsTrait::logoutProgrammatically`. Also removed the unused `use function in_array` import.

🎯 Why: To prevent the repeated memory allocation of constructing an array (`['MOCKSESSID', 'REMEMBERME', $sessionName]`) on every loop iteration, replacing an O(N) lookup and function call overhead with direct O(1) condition checks. This strictly adheres to the Bolt philosophy of making the codebase faster.

📊 Impact: Reduces memory footprint during programmatic logouts, avoiding the instantiation of an N-element array for every cookie present in the client jar.

🔬 Measurement: Verify changes by observing that all `tests/` pass with `phpunit`, code style checks pass with `composer cs-check`, and static analysis succeeds on max level with `composer phpstan`.

---
*PR created automatically by Jules for task [1686938514853552254](https://jules.google.com/task/1686938514853552254) started by @TavoNiievez*