### PR TITLE
⚡ Bolt: [performance improvement] Optimize `logoutProgrammatically` cookie cleanup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Optimized logoutProgrammatically session cookies cleanup
+**Learning:** Found an O(N) lookup pattern inside a loop iterating over cookies in `SessionAssertionsTrait::logoutProgrammatically`. `in_array` was used with a dynamically created array to match cookie names. This causes redundant memory allocation and method calls on every iteration.
+**Action:** Replaced `in_array` with direct strict equality comparisons (`===`) and a logical OR (`||`) check. Also extracted `$cookie->getName()` into a variable to avoid calling it repeatedly if the first condition fails. This eliminates array allocations inside the loop and improves performance without sacrificing readability.

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -20,7 +20,6 @@ use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
 use function class_exists;
 use function get_debug_type;
-use function in_array;
 use function is_int;
 use function is_string;
 use function serialize;
@@ -125,8 +124,9 @@ trait SessionAssertionsTrait
 
         $cookieJar = $this->getClient()->getCookieJar();
         foreach ($cookieJar->all() as $cookie) {
-            if (in_array($cookie->getName(), ['MOCKSESSID', 'REMEMBERME', $sessionName], true)) {
-                $cookieJar->expire($cookie->getName());
+            $cookieName = $cookie->getName();
+            if ($cookieName === 'MOCKSESSID' || $cookieName === 'REMEMBERME' || $cookieName === $sessionName) {
+                $cookieJar->expire($cookieName);
             }
         }
         $cookieJar->flushExpiredCookies();


### PR DESCRIPTION
💡 **What**: Replaced the `in_array` check inside the `logoutProgrammatically` cookie iteration loop with a strict equality (`===`) and logical OR (`||`) condition. Extracted the cookie name into a variable. Removed unused `in_array` import.

🎯 **Why**: The `in_array` approach constructs an array on every single iteration of the loop over all cookies. This introduces redundant O(N) lookups and memory allocation overhead. Replacing it with strict equality checks is an O(1) operation that avoids array instantiation entirely.

📊 **Impact**: Faster execution when iterating over a user's session cookies during logout, avoiding repeated allocations.

🔬 **Measurement**: Verify by running `vendor/bin/phpunit tests/` to ensure no functionality is broken. Tests have been executed and confirm logic remains 100% functional.

---
*PR created automatically by Jules for task [7949583707938590012](https://jules.google.com/task/7949583707938590012) started by @TavoNiievez*