### PR TITLE
🎨 Palette (DX): Enforce Type Safety for Internal Debug Collectors

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2026-04-12 - Enforce Type Safety for Internal Debug Collectors
+**Learning:** Method parameters accepting generic primitive strings (like `$name` for data collectors) bypass IDE autocompletion and static analysis, leading to "mystery meat" inputs.
+**Action:** Replaced the primitive string parameter with a strict `DataCollectorName` Enum in `Symfony::debugCollector()`, extracting its `->value` internally. This enforces type safety at the method boundary while remaining transparent to the underlying Profile API.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -389,10 +389,10 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             return;
         }
 
-        $this->debugCollector($profile, DataCollectorName::SECURITY->value);
-        $this->debugCollector($profile, DataCollectorName::MAILER->value);
-        $this->debugCollector($profile, DataCollectorName::NOTIFIER->value);
-        $this->debugCollector($profile, DataCollectorName::TIME->value);
+        $this->debugCollector($profile, DataCollectorName::SECURITY);
+        $this->debugCollector($profile, DataCollectorName::MAILER);
+        $this->debugCollector($profile, DataCollectorName::NOTIFIER);
+        $this->debugCollector($profile, DataCollectorName::TIME);
     }
 
     protected function doRebootClientKernel(): void
@@ -463,13 +463,13 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         $this->debugSection('Time', sprintf('%.2f ms', $timeCollector->getDuration()));
     }
 
-    private function debugCollector(Profile $profile, string $name): void
+    private function debugCollector(Profile $profile, DataCollectorName $name): void
     {
-        if (!$profile->hasCollector($name)) {
+        if (!$profile->hasCollector($name->value)) {
             return;
         }
 
-        $collector = $profile->getCollector($name);
+        $collector = $profile->getCollector($name->value);
         match (true) {
             $collector instanceof SecurityDataCollector => $this->debugSecurityData($collector),
             $collector instanceof MessageDataCollector => $this->debugMailerData($collector),


### PR DESCRIPTION
💡 What: Replaced the generic primitive string `$name` parameter in the internal `Symfony::debugCollector` method with a strict `DataCollectorName` Enum.
🎯 Why: Passing raw strings to internal methods leads to "mystery meat" parameters where the valid inputs are unknown without consulting documentation or underlying implementation details. By requiring a specific Enum, the method boundary is strongly typed, enforcing correct usage and preventing typos.
🛠️ Tooling: This change significantly improves IDE autocompletion (users will be prompted with valid `DataCollectorName` cases instead of guessing strings) and allows PHPStan to statically verify that only valid collector names are passed to the method. The change does not alter any underlying Profile API logic, as the Enum's underlying `->value` is extracted immediately within the method body.

---
*PR created automatically by Jules for task [13974375048066856946](https://jules.google.com/task/13974375048066856946) started by @TavoNiievez*