### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,0 @@
-## Codebase-Specific Performance Anti-Pattern: Repetitive DI Container Lookups in Assertion Loops
-
-**Learning:** The `seeSessionHasValues` method inside `SessionAssertionsTrait` iterated through an array of bindings and called `seeInSession` for each item. `seeInSession` in turn called `getCurrentSession()`, which triggers a Service Container check (`$this->_getContainer()->has('session')`) or Service retrieval on every iteration. This is O(N) container lookups for an array of size N.
-**Action:** Replaced repetitive lookups by pulling the session object once before the loop and inlining the assertions (`$session->has` and `$session->get`). This optimization pattern should be applied wherever arrays are validated against Symfony services or components that can be retrieved once.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## Codebase-Specific Performance Anti-Pattern: Repetitive DI Container Lookups in Assertion Loops
+
+**Learning:** The `seeSessionHasValues` method inside `SessionAssertionsTrait` iterated through an array of bindings and called `seeInSession` for each item. `seeInSession` in turn called `getCurrentSession()`, which triggers a Service Container check (`$this->_getContainer()->has('session')`) or Service retrieval on every iteration. This is O(N) container lookups for an array of size N.
+**Action:** Replaced repetitive lookups by pulling the session object once before the loop and inlining the assertions (`$session->has` and `$session->get`). This optimization pattern should be applied wherever arrays are validated against Symfony services or components that can be retrieved once.

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -164,15 +164,18 @@ trait SessionAssertionsTrait
      */
     public function seeSessionHasValues(array $bindings): void
     {
+        $session = $this->getCurrentSession();
+
         foreach ($bindings as $key => $value) {
             if (!is_int($key)) {
-                $this->seeInSession($key, $value);
+                $this->assertTrue($session->has($key), "No session attribute with name '{$key}'");
+                $this->assertSame($value, $session->get($key));
                 continue;
             }
             if (!is_string($value)) {
                 throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($value)));
             }
-            $this->seeInSession($value);
+            $this->assertTrue($session->has($value), "No session attribute with name '{$value}'");
         }
     }
 


### PR DESCRIPTION
💡 What: Retrieved the current session once before iterating through bindings, and inlined `assertTrue` and `assertSame` assertions instead of repeatedly calling `seeInSession`.
🎯 Why: Calling `seeInSession` inside a loop triggered `$this->getCurrentSession()` repeatedly, causing O(N) repetitive DI container service lookups/checks.
📊 Impact: Eliminates unnecessary overhead and memory usage during array iteration for session assertions, shaving off milliseconds in test execution time.
🔬 Measurement: Run `vendor/bin/phpunit tests/SessionAssertionsTest.php` and observe standard fast execution speeds while guaranteeing no regressions.

---
*PR created automatically by Jules for task [17982291594684307808](https://jules.google.com/task/17982291594684307808) started by @TavoNiievez*