### PR TITLE
🎨 Palette (DX): Replace vague variable name in `DoctrineAssertionsTrait`

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Replace Vague Variable Names]
+**Learning:** Vague variable names like `$mixed` increase cognitive load, while context-specific names like `$entityOrClass` make the code self-documenting.
+**Action:** Always rename vague variables (e.g., `$mixed`, `$data`, `$value`) to more descriptive names indicating their actual purpose or expected type when refactoring.

--- a/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
@@ -44,12 +44,12 @@ trait DoctrineAssertionsTrait
      * $I->grabRepository(UserRepositoryInterface::class); // interface
      * ```
      *
-     * @param  object|class-string $mixed
+     * @param  object|class-string $entityOrClass
      * @return EntityRepository<object>
      */
-    public function grabRepository(object|string $mixed): EntityRepository
+    public function grabRepository(object|string $entityOrClass): EntityRepository
     {
-        $id = is_object($mixed) ? $mixed::class : $mixed;
+        $id = is_object($entityOrClass) ? $entityOrClass::class : $entityOrClass;
 
         if (interface_exists($id) || is_subclass_of($id, EntityRepository::class)) {
             $repo = $this->grabService($id);


### PR DESCRIPTION
💡 What: Renamed the parameter `$mixed` to `$entityOrClass` in `DoctrineAssertionsTrait::grabRepository`.
🎯 Why: Reduces cognitive load by providing a context-specific name, making the method signature self-documenting without needing to read the internals.
🛠️ Tooling: Improves IDE readability and aligns with clean code principles.

---
*PR created automatically by Jules for task [11873406249710040225](https://jules.google.com/task/11873406249710040225) started by @TavoNiievez*