### PR TITLE
🎨 Palette (DX): Rename vague $mixed parameter in grabRepository

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-04-14 - Rename mystery meat parameters for clarity
+**Learning:** Method parameters with vague, type-like names (e.g. `$mixed`, `$data`, `$value`) force developers to read the PHPDoc or function implementation to understand what is actually required. This increases cognitive load.
+**Action:** Always rename vague parameter names to descriptive ones that indicate their purpose or expected domain object (e.g. `$mixed` -> `$entityOrClass`), strictly improving code discoverability.

--- a/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
@@ -44,12 +44,12 @@ trait DoctrineAssertionsTrait
      * $I->grabRepository(UserRepositoryInterface::class); // interface
      * ```
      *
-     * @param  object|class-string $mixed
+     * @param  object|class-string $entityOrClass
      * @return EntityRepository<object>
      */
-    public function grabRepository(object|string $mixed): EntityRepository
+    public function grabRepository(object|string $entityOrClass): EntityRepository
     {
-        $id = is_object($mixed) ? $mixed::class : $mixed;
+        $id = is_object($entityOrClass) ? $entityOrClass::class : $entityOrClass;
 
         if (interface_exists($id) || is_subclass_of($id, EntityRepository::class)) {
             $repo = $this->grabService($id);


### PR DESCRIPTION
💡 What: Renamed `$mixed` parameter to `$entityOrClass` in `grabRepository`.

🎯 Why: The previous parameter name `$mixed` was vague and inaccurate (it accepted `object|string`). Renaming it to `$entityOrClass` provides instant context about what the parameter should be, reducing cognitive load and the need to read method implementation details.

🛠️ Tooling: Improves IDE readability without changing type hints or logic. Tested via PHPStan (level max) and PHPUnit.

---
*PR created automatically by Jules for task [11232449771747446774](https://jules.google.com/task/11232449771747446774) started by @TavoNiievez*