### PR TITLE
🎨 Palette (DX): Replace version_compare with class_exists in NotifierAssertionsTrait

### DIFF
--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -6,7 +6,6 @@ namespace Codeception\Module\Symfony;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\LogicalNot;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Event\NotificationEvents;
 use Symfony\Component\Notifier\EventListener\NotificationLoggerListener;
@@ -14,7 +13,7 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Test\Constraint as NotifierConstraint;
 
 use function array_key_last;
-use function version_compare;
+use function class_exists;
 
 trait NotifierAssertionsTrait
 {
@@ -243,8 +242,8 @@ trait NotifierAssertionsTrait
 
     protected function getNotificationEvents(): NotificationEvents
     {
-        // @phpstan-ignore if.alwaysFalse
-        if (version_compare(Kernel::VERSION, '6.2', '<')) {
+
+        if (!class_exists(NotificationEvents::class)) {
             Assert::fail('Notifier assertions require Symfony 6.2 or higher.');
         }
 


### PR DESCRIPTION
💡 **What:** Replaced the `version_compare(Kernel::VERSION, '6.2', '<')` check in `NotifierAssertionsTrait` with `!class_exists(NotificationEvents::class)`.
🎯 **Why:** This robust feature detection allows us to remove the `@phpstan-ignore if.alwaysFalse` comment, ensuring strict adherence to our no `@phpstan-ignore` policy, reducing cognitive load regarding static analysis suppressions, and making the code more statically analyzable. It also avoids an unneeded dependency check on the overall Kernel version for a specific component's feature.
🛠️ **Tooling:** This improves PHPStan's ability to natively infer code reachability without relying on potentially brittle framework version string parsing.

---
*PR created automatically by Jules for task [12580759711554651440](https://jules.google.com/task/12580759711554651440) started by @TavoNiievez*