### PR TITLE
⚡ Bolt: [performance improvement] Replace Finder with glob for Kernel search

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -41,7 +41,6 @@ use ReflectionException;
 use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Profiler\Profile;
@@ -334,8 +333,8 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         if (file_exists($expectedKernelPath)) {
             include_once $expectedKernelPath;
         } else {
-            foreach ((new Finder())->name('*Kernel.php')->depth('0')->in($path) as $file) {
-                include_once $file->getRealPath();
+            foreach (glob($path . DIRECTORY_SEPARATOR . '*Kernel.php') ?: [] as $file) {
+                include_once $file;
             }
         }
 


### PR DESCRIPTION
💡 What: Replaced `Symfony\Component\Finder\Finder` with native `glob()` in `getKernelClass` and removed the unused `Finder` import.
🎯 Why: `Finder` adds unnecessary object instantiation and overhead for a simple single-directory wildcard search (`depth('0')`), which is a micro-bottleneck during kernel initialization.
📊 Impact: Reduces memory overhead and class loading operations for the module's setup phase.
🔬 Measurement: Verify tests still pass with `vendor/bin/phpunit tests/`.

---
*PR created automatically by Jules for task [7630727281764668411](https://jules.google.com/task/7630727281764668411) started by @TavoNiievez*