### PR TITLE
⚡ Bolt: [performance improvement] array_map and array_filter loop fusion

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -50,8 +50,6 @@ use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
 use Symfony\Component\Notifier\DataCollector\NotificationDataCollector;
 use Symfony\Component\VarDumper\Cloner\Data;
 
-use function array_filter;
-use function array_map;
 use function class_exists;
 use function codecept_root_dir;
 use function count;
@@ -61,6 +59,7 @@ use function implode;
 use function ini_get;
 use function ini_set;
 use function is_object;
+use function is_scalar;
 use function is_subclass_of;
 use function sprintf;
 
@@ -445,7 +444,13 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
             $roles = $roles->getValue(true);
         }
 
-        $rolesStr = implode(',', array_map('strval', array_filter((array) $roles, 'is_scalar')));
+        $rolesArr = [];
+        foreach ((array) $roles as $role) {
+            if (is_scalar($role)) {
+                $rolesArr[] = (string) $role;
+            }
+        }
+        $rolesStr = implode(',', $rolesArr);
         $this->debugSection('User', sprintf('%s [%s]', $securityCollector->getUser(), $rolesStr));
     }
 


### PR DESCRIPTION
💡 What: Replaced chained `array_map` and `array_filter` calls with a single `foreach` loop when extracting string roles in `src/Codeception/Module/Symfony.php`. Removed corresponding unused imports.

🎯 Why: Fuses two array iteration loops into a single pass. Eliminates intermediate array allocations and the overhead of calling `is_scalar` and `strval` string callbacks via `array_filter` and `array_map`.

📊 Impact: Minor reduction in memory usage and execution time during security profile debugging by avoiding intermediate arrays and closure dispatch overhead.

🔬 Measurement: Verify with `vendor/bin/phpunit tests/` and `vendor/bin/phpstan analyse src --level=max` to ensure type-safe scalar extraction remains functionally equivalent.

---
*PR created automatically by Jules for task [12443413386734045346](https://jules.google.com/task/12443413386734045346) started by @TavoNiievez*