### PR TITLE
🎨 Palette (DX): Rename mystery meat parameters and variables for clarity

### DIFF
--- a/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/BrowserAssertionsTrait.php
@@ -273,8 +273,8 @@ trait BrowserAssertionsTrait
         $request = $this->getClient()->getRequest();
         $this->assertThat($request, new RequestAttributeValueSame('_route', $expectedRoute));
 
-        foreach ($parameters as $key => $value) {
-            $this->assertThat($request, new RequestAttributeValueSame($key, (string) $value), $message);
+        foreach ($parameters as $key => $parameterValue) {
+            $this->assertThat($request, new RequestAttributeValueSame($key, (string) $parameterValue), $message);
         }
     }
 
@@ -366,8 +366,8 @@ trait BrowserAssertionsTrait
         $selector = sprintf('form[name=%s]', $name);
 
         $params = [];
-        foreach ($fields as $key => $value) {
-            $params[$name . $key] = $value;
+        foreach ($fields as $key => $fieldValue) {
+            $params[$name . $key] = $fieldValue;
         }
 
         $node = $this->getClient()->getCrawler()->filter($selector);

--- a/src/Codeception/Module/Symfony/DomCrawlerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/DomCrawlerAssertionsTrait.php
@@ -170,10 +170,10 @@ trait DomCrawlerAssertionsTrait
         $this->assertThatCrawler($constraint, $message);
     }
 
-    private function assertInputValue(string $fieldName, string $value, bool $same, string $message): void
+    private function assertInputValue(string $fieldName, string $expectedValue, bool $same, string $message): void
     {
         $this->assertThatCrawler(new CrawlerSelectorExists("input[name=\"$fieldName\"]"), $message);
-        $constraint = new CrawlerSelectorAttributeValueSame("input[name=\"$fieldName\"]", 'value', $value);
+        $constraint = new CrawlerSelectorAttributeValueSame("input[name=\"$fieldName\"]", 'value', $expectedValue);
         if (!$same) {
             $constraint = new LogicalNot($constraint);
         }

--- a/src/Codeception/Module/Symfony/FormAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/FormAssertionsTrait.php
@@ -214,11 +214,11 @@ trait FormAssertionsTrait
     /** @return array<string, mixed> */
     private function getRawCollectorData(FormDataCollector $collector): array
     {
-        $data = $collector->getData();
-        if ($data instanceof Data) {
-            $data = $data->getValue(true);
+        $collectorData = $collector->getData();
+        if ($collectorData instanceof Data) {
+            $collectorData = $collectorData->getValue(true);
         }
         /** @var array<string, mixed> */
-        return is_array($data) ? $data : [];
+        return is_array($collectorData) ? $collectorData : [];
     }
 }

--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -145,13 +145,13 @@ trait HttpClientAssertionsTrait
         return $clientData['traces'];
     }
 
-    private function extractValue(mixed $value): mixed
+    private function extractValue(mixed $traceData): mixed
     {
         return match (true) {
-            $value instanceof Data => $value->getValue(true),
-            is_object($value) && method_exists($value, 'getValue') => $value->getValue(true),
-            $value instanceof Stringable => (string) $value,
-            default => $value,
+            $traceData instanceof Data => $traceData->getValue(true),
+            is_object($traceData) && method_exists($traceData, 'getValue') => $traceData->getValue(true),
+            $traceData instanceof Stringable => (string) $traceData,
+            default => $traceData,
         };
     }
 

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -243,8 +243,7 @@ trait NotifierAssertionsTrait
 
     protected function getNotificationEvents(): NotificationEvents
     {
-        // @phpstan-ignore if.alwaysFalse
-        if (version_compare(Kernel::VERSION, '6.2', '<')) {
+        if (!class_exists(NotificationEvents::class)) {
             Assert::fail('Notifier assertions require Symfony 6.2 or higher.');
         }
 


### PR DESCRIPTION
💡 What: Replaced vague `$value` and `$data` variables with descriptive names like `$parameterValue`, `$fieldValue`, `$expectedValue`, `$traceData` and `$collectorData` in several assertion traits. Also fixed a PHPStan ignore annotation in `NotifierAssertionsTrait`.

🎯 Why: Method parameters and internal variables with vague names force developers to read the implementation to understand what is actually required or processed. Descriptive names strictly improve code discoverability and reduce cognitive load.

🛠️ Tooling: Improved PHPStan static analysis by replacing `@phpstan-ignore if.alwaysFalse` with a robust `class_exists()` check in `NotifierAssertionsTrait.php`.

---
*PR created automatically by Jules for task [648288995406581027](https://jules.google.com/task/648288995406581027) started by @TavoNiievez*