### PR TITLE
⚡ Bolt: [performance improvement] Replace Finder with glob for shallow directory search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,9 @@
 **Learning:** When checking if a `DomCrawler` filter matched any elements, `assertGreaterThan(0, count($node))` was used. Since `$node` is an object implementing `Countable`, the global `count()` function checks the interface and dispatches to `$node->count()`. Calling `$node->count()` directly bypasses this overhead, resulting in slightly faster execution times (~2x speedup in isolated microbenchmarks).
 
 **Action:** Replaced `count($node)` with `$node->count()` in `BrowserAssertionsTrait` and `FormAssertionsTrait`.
+
+## Finder vs glob for Shallow Directory Searches
+
+**Learning:** Using `Symfony\Component\Finder\Finder` for simple, single-directory file searches (depth 0) introduces unnecessary object instantiation and Iterator overhead. Native PHP `glob()` is significantly faster for this specific use case as it operates directly at the C level without the abstraction layers of the Finder component.
+
+**Action:** Replaced `(new Finder())->name('*Kernel.php')->depth('0')->in($path)` with `glob($path . DIRECTORY_SEPARATOR . '*Kernel.php') ?: []` in `Symfony.php`'s `getKernelClass` method.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -334,8 +334,8 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         if (file_exists($expectedKernelPath)) {
             include_once $expectedKernelPath;
         } else {
-            foreach ((new Finder())->name('*Kernel.php')->depth('0')->in($path) as $file) {
-                include_once $file->getRealPath();
+            foreach (glob($path . DIRECTORY_SEPARATOR . '*Kernel.php') ?: [] as $file) {
+                include_once $file;
             }
         }
 


### PR DESCRIPTION
💡 **What:** Replaced the use of `Symfony\Component\Finder\Finder` with the native PHP `glob()` function for the `*Kernel.php` file search in `getKernelClass` within `src/Codeception/Module/Symfony.php`.
🎯 **Why:** Using `Finder` for a simple, single-directory file search (depth 0) introduces unnecessary object instantiation and Iterator overhead. `glob()` operates directly at the C level, making it significantly faster for this specific use case.
📊 **Impact:** Reduces execution time and memory overhead during module initialization by avoiding the instantiation of the `Finder` component.
🔬 **Measurement:** The test suite (`vendor/bin/phpunit tests/`) passes successfully, confirming no regressions in file discovery logic. The optimization also passed static analysis (`vendor/bin/phpstan analyse src --level=max`) and coding standards checks (`composer cs-check`).

---
*PR created automatically by Jules for task [7467135604398111220](https://jules.google.com/task/7467135604398111220) started by @TavoNiievez*