### PR TITLE
⚡ Bolt: [performance improvement] Optimize file search in `getKernelClass`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,9 @@
 **Learning:** When checking if a `DomCrawler` filter matched any elements, `assertGreaterThan(0, count($node))` was used. Since `$node` is an object implementing `Countable`, the global `count()` function checks the interface and dispatches to `$node->count()`. Calling `$node->count()` directly bypasses this overhead, resulting in slightly faster execution times (~2x speedup in isolated microbenchmarks).
 
 **Action:** Replaced `count($node)` with `$node->count()` in `BrowserAssertionsTrait` and `FormAssertionsTrait`.
+
+## Finder vs glob Overhead
+
+**Learning:** When searching for files in a single directory without recursion (depth 0), using `Symfony\Component\Finder\Finder` introduces unnecessary object instantiation and iteration overhead. Native `glob()` is significantly faster for these simple use cases, though it requires handling potential empty results correctly (e.g., `glob(...) ?: []`).
+
+**Action:** Replaced `Finder` with `glob()` in `src/Codeception/Module/Symfony.php`'s `getKernelClass()` method.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -41,7 +41,6 @@ use ReflectionException;
 use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Profiler\Profile;
@@ -334,8 +333,8 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         if (file_exists($expectedKernelPath)) {
             include_once $expectedKernelPath;
         } else {
-            foreach ((new Finder())->name('*Kernel.php')->depth('0')->in($path) as $file) {
-                include_once $file->getRealPath();
+            foreach (glob($path . DIRECTORY_SEPARATOR . '*Kernel.php') ?: [] as $file) {
+                include_once $file;
             }
         }
 


### PR DESCRIPTION
💡 **What:** Replaced the use of `Symfony\Component\Finder\Finder` with the native PHP `glob()` function in `src/Codeception/Module/Symfony.php` when searching for `*Kernel.php` files. The unused `Finder` import was also removed.

🎯 **Why:** The previous code instantiated the `Symfony\Component\Finder\Finder` component just to search for a specific file pattern in a single directory without recursion (depth 0). The `Finder` component introduces significant object instantiation and iteration overhead. Native `glob()` accomplishes the exact same goal safely but is much faster and more memory efficient.

📊 **Impact:** Reduces object instantiation and file system iteration overhead during module initialization when searching for kernel files.

🔬 **Measurement:** Verify tests run properly by executing `vendor/bin/phpunit tests/`. Execute `composer cs-check` and `vendor/bin/phpstan analyse src --level=max` to ensure code health is preserved.

---
*PR created automatically by Jules for task [8573614962095267873](https://jules.google.com/task/8573614962095267873) started by @TavoNiievez*