### PR TITLE
🎨 Palette (DX): Add native return type hint to grabSecurityService

### DIFF
--- a/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SecurityAssertionsTrait.php
@@ -142,8 +142,7 @@ trait SecurityAssertionsTrait
             && $this->grabSecurityService()->isGranted(AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED);
     }
 
-    /** @return Security */
-    protected function grabSecurityService()
+    protected function grabSecurityService(): Security
     {
         /** @var Security */
         return $this->grabService('security.helper');


### PR DESCRIPTION
💡 What: Replaced the PHPDoc `/** @return Security */` with a native PHP return type hint `: Security` on the `grabSecurityService` method in `SecurityAssertionsTrait.php`.

🎯 Why: To improve type safety at runtime and reduce cognitive load by making the method signature self-documenting.

🛠️ Tooling: Improves PHPStan analysis and IDE autocompletion by explicitly defining the return type via the type system rather than annotations.

---
*PR created automatically by Jules for task [18292117734118744546](https://jules.google.com/task/18292117734118744546) started by @TavoNiievez*