### PR TITLE
⚡ Bolt: [performance improvement] Replace Finder with native glob

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,8 @@
 **Learning:** When checking if a `DomCrawler` filter matched any elements, `assertGreaterThan(0, count($node))` was used. Since `$node` is an object implementing `Countable`, the global `count()` function checks the interface and dispatches to `$node->count()`. Calling `$node->count()` directly bypasses this overhead, resulting in slightly faster execution times (~2x speedup in isolated microbenchmarks).
 
 **Action:** Replaced `count($node)` with `$node->count()` in `BrowserAssertionsTrait` and `FormAssertionsTrait`.
+## 2026-05-03 - Symfony Finder vs Native glob Overhead
+
+**Learning:** When searching for files in a single directory without recursion (depth 0), instantiating a full `Symfony\Component\Finder\Finder` object introduces unnecessary overhead compared to native PHP `glob()`. `glob()` operates directly at the C-level and avoids object creation, Iterator setup, and method dispatch overhead. For simple patterns like `*Kernel.php` in a specific path, `glob()` is measurably faster.
+
+**Action:** Replaced `(new Finder())->name('*Kernel.php')->depth('0')->in()` with `glob($path . DIRECTORY_SEPARATOR . '*Kernel.php')` in `src/Codeception/Module/Symfony.php`.

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -41,7 +41,6 @@ use ReflectionException;
 use Symfony\Bundle\SecurityBundle\DataCollector\SecurityDataCollector;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Profiler\Profile;
@@ -334,8 +333,8 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
         if (file_exists($expectedKernelPath)) {
             include_once $expectedKernelPath;
         } else {
-            foreach ((new Finder())->name('*Kernel.php')->depth('0')->in($path) as $file) {
-                include_once $file->getRealPath();
+            foreach (glob($path . DIRECTORY_SEPARATOR . '*Kernel.php') ?: [] as $file) {
+                include_once $file;
             }
         }
 


### PR DESCRIPTION
💡 What: Replaced the usage of `Symfony\Component\Finder\Finder` with native PHP `glob()` when searching for the `*Kernel.php` file in `src/Codeception/Module/Symfony.php`, and removed the unused `Finder` import.

🎯 Why: For simple, single-directory (depth 0) searches, instantiating the full Symfony `Finder` component introduces unnecessary object instantiation, Iterator setup, and method dispatch overhead. `glob()` is a native C-level function that accomplishes the exact same task significantly faster.

📊 Impact: Reduces bootstrap time slightly by avoiding unnecessary object instantiation and method calls.

🔬 Measurement: Run `vendor/bin/phpunit tests/` and `composer cs-check` to verify that functionality is preserved and code standards are met. The optimization can be benchmarked by repeatedly bootstrapping the module and observing the reduced overhead in `getKernelClass`.

---
*PR created automatically by Jules for task [12268659694917922032](https://jules.google.com/task/12268659694917922032) started by @TavoNiievez*