### PR TITLE
🎨 Palette (DX): [Improve Generics in DoctrineAssertionsTrait::grabRepository]

### DIFF
--- a/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
@@ -44,8 +44,9 @@ trait DoctrineAssertionsTrait
      * $I->grabRepository(UserRepositoryInterface::class); // interface
      * ```
      *
-     * @param  object|class-string $entityOrClass
-     * @return EntityRepository<object>
+     * @template T of object
+     * @param T|class-string<T> $entityOrClass
+     * @return EntityRepository<T>
      */
     public function grabRepository(object|string $entityOrClass): EntityRepository
     {


### PR DESCRIPTION
💡 What: Added template generic types (`@template T of object`) to `grabRepository` to map the input class string/object to the correct generic `EntityRepository<T>`.
🎯 Why: Improves IDE autocomplete when calling methods on the returned repository, and reduces the need for `@var` docblocks when developers use this method.
🛠️ Tooling: Improves PHPStan and LSP support by passing the type through.

---
*PR created automatically by Jules for task [7113591042779450278](https://jules.google.com/task/7113591042779450278) started by @TavoNiievez*