### PR TITLE
🎨 Palette (DX): Improve grabRepository autocompletion with Generics

### DIFF
--- a/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
@@ -44,8 +44,9 @@ trait DoctrineAssertionsTrait
      * $I->grabRepository(UserRepositoryInterface::class); // interface
      * ```
      *
-     * @param  object|class-string $entityOrClass
-     * @return EntityRepository<object>
+     * @template T of object
+     * @param  T|class-string<T> $entityOrClass
+     * @return EntityRepository<T>
      */
     public function grabRepository(object|string $entityOrClass): EntityRepository
     {


### PR DESCRIPTION
💡 What: Updated the PHPDoc for `DoctrineAssertionsTrait::grabRepository()` to use Generics (`@template T of object`, `@param T|class-string<T> $entityOrClass`, `@return EntityRepository<T>`).

🎯 Why: Previously, this method returned `EntityRepository<object>`, meaning the developer had no idea what entity they were working with. This change significantly reduces cognitive load by ensuring the returned repository inherits the specific entity type passed to the method.

🛠️ Tooling: Improves IDE autocompletion ("Go to definition" on returned entities) and passes PHPStan strict level 8 (or max) static analysis checks without modifying business logic.

---
*PR created automatically by Jules for task [3844156474792522657](https://jules.google.com/task/3844156474792522657) started by @TavoNiievez*