### PR TITLE
🎨 Palette (DX): Replace @phpstan-ignore with robust class_exists check

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,3 +1,7 @@
 ## 2024-04-14 - Rename mystery meat parameters for clarity
 **Learning:** Method parameters with vague, type-like names (e.g. `$mixed`, `$data`, `$value`) force developers to read the PHPDoc or function implementation to understand what is actually required. This increases cognitive load.
 **Action:** Always rename vague parameter names to descriptive ones that indicate their purpose or expected domain object (e.g. `$mixed` -> `$entityOrClass`), strictly improving code discoverability.
+
+## 2024-05-10 - [Removing @phpstan-ignore with Robust Checks]
+**Learning:** Usage of `@phpstan-ignore` hides potential bugs and violates strict static analysis standards, especially when dynamic runtime versions (e.g., `Kernel::VERSION`) are evaluated incorrectly by PHPStan during static analysis.
+**Action:** Replace `version_compare` or dynamic constants with robust, statically analyzable checks like `class_exists()` or `method_exists()` to satisfy PHPStan and enforce strict type safety without suppression.

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -6,15 +6,14 @@ namespace Codeception\Module\Symfony;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\LogicalNot;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Event\NotificationEvents;
 use Symfony\Component\Notifier\EventListener\NotificationLoggerListener;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Test\Constraint as NotifierConstraint;
 
+use function class_exists;
 use function array_key_last;
-use function version_compare;
 
 trait NotifierAssertionsTrait
 {
@@ -243,8 +242,7 @@ trait NotifierAssertionsTrait
 
     protected function getNotificationEvents(): NotificationEvents
     {
-        // @phpstan-ignore if.alwaysFalse
-        if (version_compare(Kernel::VERSION, '6.2', '<')) {
+        if (!class_exists(NotificationEvents::class)) {
             Assert::fail('Notifier assertions require Symfony 6.2 or higher.');
         }
 


### PR DESCRIPTION
💡 **What:** Replaced the fragile `version_compare` evaluation of `Kernel::VERSION` with a robust `class_exists(NotificationEvents::class)` check in `NotifierAssertionsTrait`. This allowed the removal of the forbidden `@phpstan-ignore` annotation and unused imports (`Kernel` and `version_compare`).

🎯 **Why:** Usage of `@phpstan-ignore` hides potential bugs and violates strict static analysis rules. Because `Kernel::VERSION` evaluates dynamically based on the current install, static analyzers like PHPStan incorrectly flag it as always true or false. A `class_exists` check provides proper, statically resolvable feature detection, drastically improving codebase health and adherence to type safety constraints without suppression.

🛠️ **Tooling:** This entirely satisfies PHPStan without any ignore hints, ensuring our code remains fully and strictly statically analyzable.

---
*PR created automatically by Jules for task [16628204991915230340](https://jules.google.com/task/16628204991915230340) started by @TavoNiievez*