### PR TITLE
🎨 Palette (DX): Rename vague parameter in extractValue

### DIFF
--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -145,13 +145,13 @@ trait HttpClientAssertionsTrait
         return $clientData['traces'];
     }
 
-    private function extractValue(mixed $value): mixed
+    private function extractValue(mixed $traceData): mixed
     {
         return match (true) {
-            $value instanceof Data => $value->getValue(true),
-            is_object($value) && method_exists($value, 'getValue') => $value->getValue(true),
-            $value instanceof Stringable => (string) $value,
-            default => $value,
+            $traceData instanceof Data => $traceData->getValue(true),
+            is_object($traceData) && method_exists($traceData, 'getValue') => $traceData->getValue(true),
+            $traceData instanceof Stringable => (string) $traceData,
+            default => $traceData,
         };
     }
 


### PR DESCRIPTION
💡 What: Renamed the vague `$value` parameter to `$traceData` in the `extractValue` method of `HttpClientAssertionsTrait`.
🎯 Why: Vague variables like `$value` increase cognitive load, forcing developers to read the implementation to understand what data is expected. Naming it `$traceData` provides immediate context.
🛠️ Tooling: Enhances discoverability and self-documentation without changing business logic.

---
*PR created automatically by Jules for task [16192626470376047389](https://jules.google.com/task/16192626470376047389) started by @TavoNiievez*