### PR TITLE
🎨 Palette (DX): Rename mystery meat parameters for clarity

### DIFF
--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -74,12 +74,12 @@ trait SessionAssertionsTrait
      * $I->dontSeeInSession('attribute', 'value');
      * ```
      */
-    public function dontSeeInSession(string $attribute, mixed $value = null): void
+    public function dontSeeInSession(string $attribute, mixed $expectedValue = null): void
     {
         $session = $this->getCurrentSession();
-        $value === null
+        $expectedValue === null
             ? $this->assertFalse($session->has($attribute), "Session attribute '{$attribute}' exists.")
-            : $this->assertNotSame($value, $session->get($attribute));
+            : $this->assertNotSame($expectedValue, $session->get($attribute));
     }
 
     /**
@@ -141,13 +141,13 @@ trait SessionAssertionsTrait
      * $I->seeInSession('attribute', 'value');
      * ```
      */
-    public function seeInSession(string $attribute, mixed $value = null): void
+    public function seeInSession(string $attribute, mixed $expectedValue = null): void
     {
         $session = $this->getCurrentSession();
         $this->assertTrue($session->has($attribute), "No session attribute with name '{$attribute}'");
 
-        if ($value !== null) {
-            $this->assertSame($value, $session->get($attribute));
+        if ($expectedValue !== null) {
+            $this->assertSame($expectedValue, $session->get($attribute));
         }
     }
 


### PR DESCRIPTION
💡 **What:** Renamed the vague `$value` parameter in multiple traits to more descriptive names (`$expectedValue` and `$traceData`).
🎯 **Why:** "Mystery meat" parameter names like `$value` force developers to look at the implementation or PHPDoc to understand what is being requested or returned. Naming it `$expectedValue` (in `SessionAssertionsTrait`) or `$traceData` (in `HttpClientAssertionsTrait`) instantly reveals its domain purpose and context, reducing cognitive load.
🛠️ **Tooling:** Enhances IDE "Go To Definition" parameter clarity and auto-completion hints. No logic changes were made.

---
*PR created automatically by Jules for task [8028303447056838066](https://jules.google.com/task/8028303447056838066) started by @TavoNiievez*