### PR TITLE
🎨 Palette (DX): Refactor vague variable names for clarity

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,3 +1,6 @@
 ## 2024-04-14 - Rename mystery meat parameters for clarity
 **Learning:** Method parameters with vague, type-like names (e.g. `$mixed`, `$data`, `$value`) force developers to read the PHPDoc or function implementation to understand what is actually required. This increases cognitive load.
 **Action:** Always rename vague parameter names to descriptive ones that indicate their purpose or expected domain object (e.g. `$mixed` -> `$entityOrClass`), strictly improving code discoverability.
+## 2024-04-14 - Refactor vague private parameter names
+**Learning:** Method parameters with vague, type-like names (e.g. `$mixed`, `$data`, `$value`) force developers to read the PHPDoc or function implementation to understand what is actually required. This increases cognitive load.
+**Action:** Always rename vague parameter names to descriptive ones that indicate their purpose or expected domain object (e.g. `$value` -> `$traceData` for trace-related extractions), strictly improving code discoverability. Safe to do on private/internal methods without BC break concerns.

--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -145,13 +145,13 @@ trait HttpClientAssertionsTrait
         return $clientData['traces'];
     }
 
-    private function extractValue(mixed $value): mixed
+    private function extractValue(mixed $traceData): mixed
     {
         return match (true) {
-            $value instanceof Data => $value->getValue(true),
-            is_object($value) && method_exists($value, 'getValue') => $value->getValue(true),
-            $value instanceof Stringable => (string) $value,
-            default => $value,
+            $traceData instanceof Data => $traceData->getValue(true),
+            is_object($traceData) && method_exists($traceData, 'getValue') => $traceData->getValue(true),
+            $traceData instanceof Stringable => (string) $traceData,
+            default => $traceData,
         };
     }
 


### PR DESCRIPTION
💡 What: Renamed the vague `$value` parameter to `$traceData` in the private `extractValue` method.
🎯 Why: It improves code readability by describing the domain entity it typically receives, without introducing a Backwards Compatibility (BC) break since the method is private.
🛠️ Tooling: Improves discoverability without affecting PHPStan strict checks.

---
*PR created automatically by Jules for task [1101687943022209666](https://jules.google.com/task/1101687943022209666) started by @TavoNiievez*