### PR TITLE
🎨 Palette (DX): Add Generics to grabRepository

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,3 +1,3 @@
-## 2024-04-14 - Rename mystery meat parameters for clarity
-**Learning:** Method parameters with vague, type-like names (e.g. `$mixed`, `$data`, `$value`) force developers to read the PHPDoc or function implementation to understand what is actually required. This increases cognitive load.
-**Action:** Always rename vague parameter names to descriptive ones that indicate their purpose or expected domain object (e.g. `$mixed` -> `$entityOrClass`), strictly improving code discoverability.
+## 2024-05-18 - [Add Generics for Doctrine Repositories]
+**Learning:** Returning `EntityRepository` without generics forces developers to add `@var` annotations or lose autocomplete and type safety.
+**Action:** Adding `@template T of object` and updating return types dynamically `($entityOrClass is class-string<T> ? EntityRepository<T> : EntityRepository<object>)` allows IDEs and PHPStan to correctly infer the repository type when a class-string is provided to `grabRepository`.

--- a/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
@@ -44,8 +44,9 @@ trait DoctrineAssertionsTrait
      * $I->grabRepository(UserRepositoryInterface::class); // interface
      * ```
      *
-     * @param  object|class-string $entityOrClass
-     * @return EntityRepository<object>
+     * @template T of object
+     * @param object|class-string<T> $entityOrClass
+     * @return ($entityOrClass is class-string<T> ? EntityRepository<T> : EntityRepository<object>)
      */
     public function grabRepository(object|string $entityOrClass): EntityRepository
     {
@@ -56,6 +57,7 @@ trait DoctrineAssertionsTrait
             if (!($repo instanceof EntityRepository && $repo instanceof $id)) {
                 Assert::fail(sprintf("'%s' is not an entity repository", $id));
             }
+            /** @var EntityRepository<T>|EntityRepository<object> $repo */
             return $repo;
         }
 
@@ -64,7 +66,10 @@ trait DoctrineAssertionsTrait
             Assert::fail(sprintf("'%s' is not a managed Doctrine entity", $id));
         }
 
-        return $em->getRepository($id);
+        /** @var EntityRepository<T>|EntityRepository<object> $repo */
+        $repo = $em->getRepository($id);
+
+        return $repo;
     }
 
     /**


### PR DESCRIPTION
💡 **What:** Added `@template T of object` and dynamically inferred return types `($entityOrClass is class-string<T> ? EntityRepository<T> : EntityRepository<object>)` to `grabRepository` inside `DoctrineAssertionsTrait.php`.

🎯 **Why:** Returning `EntityRepository` without generics forces developers to manually annotate `@var` to tell PHPStan/IDEs what the returned repository is, otherwise they lose autocomplete and static analysis features. By adding generics, `grabRepository(User::class)` will correctly be typed as `EntityRepository<User>`, removing the "mystery meat" type.

🛠️ **Tooling:** Greatly improves IDE Autocompletion and PHPStan type checks for consumers of this repository fetching method.

---
*PR created automatically by Jules for task [10390311628646314315](https://jules.google.com/task/10390311628646314315) started by @TavoNiievez*