### PR TITLE
🎨 Palette (DX): Replace version_compare with class_exists to remove @phpstan-ignore

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,3 +1,6 @@
 ## 2024-04-14 - Rename mystery meat parameters for clarity
 **Learning:** Method parameters with vague, type-like names (e.g. `$mixed`, `$data`, `$value`) force developers to read the PHPDoc or function implementation to understand what is actually required. This increases cognitive load.
 **Action:** Always rename vague parameter names to descriptive ones that indicate their purpose or expected domain object (e.g. `$mixed` -> `$entityOrClass`), strictly improving code discoverability.
+## 2024-05-26 - [Robust Feature Detection]
+**Learning:** Suppressing static analysis errors (like `@phpstan-ignore if.alwaysFalse`) for framework version checks (`version_compare`) hides potential bugs and creates fragile code, as static analyzers cannot evaluate these checks effectively.
+**Action:** Replace dynamic framework version checks with robust, statically analyzable feature detection (e.g., `!class_exists(\Symfony\Component\Notifier\Event\NotificationEvents::class)`) to natively satisfy PHPStan and improve code resilience without needing `@phpstan-ignore`.

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -6,7 +6,6 @@ namespace Codeception\Module\Symfony;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\LogicalNot;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Event\NotificationEvents;
 use Symfony\Component\Notifier\EventListener\NotificationLoggerListener;
@@ -14,7 +13,6 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Test\Constraint as NotifierConstraint;
 
 use function array_key_last;
-use function version_compare;
 
 trait NotifierAssertionsTrait
 {
@@ -243,8 +241,7 @@ trait NotifierAssertionsTrait
 
     protected function getNotificationEvents(): NotificationEvents
     {
-        // @phpstan-ignore if.alwaysFalse
-        if (version_compare(Kernel::VERSION, '6.2', '<')) {
+        if (!class_exists(NotificationEvents::class)) {
             Assert::fail('Notifier assertions require Symfony 6.2 or higher.');
         }
 


### PR DESCRIPTION
💡 What: Replaced the dynamic framework version check (`version_compare(Kernel::VERSION, '6.2', '<')`) in `NotifierAssertionsTrait` with a statically analyzable feature check (`!class_exists(NotificationEvents::class)`). This allowed the removal of a `@phpstan-ignore if.alwaysFalse` suppression and cleaned up unused imports (`Kernel`, `version_compare`).

🎯 Why: Relying on `@phpstan-ignore` hides underlying issues and weakens static analysis guarantees. Using `class_exists` natively satisfies PHPStan because it evaluates feature availability directly rather than guessing based on a global framework version, reducing cognitive load and preventing false positives in the future.

🛠️ Tooling: Improves PHPStan analysis by removing a suppression and providing it with statically verifiable code.

---
*PR created automatically by Jules for task [6602958388975955580](https://jules.google.com/task/6602958388975955580) started by @TavoNiievez*