### PR TITLE
🎨 Palette (DX): Fix NotificationEvents version check static analysis

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,3 +1,7 @@
 ## 2024-04-14 - Rename mystery meat parameters for clarity
 **Learning:** Method parameters with vague, type-like names (e.g. `$mixed`, `$data`, `$value`) force developers to read the PHPDoc or function implementation to understand what is actually required. This increases cognitive load.
 **Action:** Always rename vague parameter names to descriptive ones that indicate their purpose or expected domain object (e.g. `$mixed` -> `$entityOrClass`), strictly improving code discoverability.
+
+## 2024-06-01 - Replace dynamic version checks for static analysis
+**Learning:** `version_compare(Kernel::VERSION, ...)` cannot always be statically analyzed and can cause PHPStan to flag `if.alwaysFalse` if it believes the condition can never be met based on minimum dependencies, forcing developers to use prohibited `@phpstan-ignore` comments.
+**Action:** Replace dynamic version checks with statically analyzable alternatives, like `class_exists()` for classes or `method_exists()` for features introduced in specific versions.

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -14,7 +14,6 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Test\Constraint as NotifierConstraint;
 
 use function array_key_last;
-use function version_compare;
 
 trait NotifierAssertionsTrait
 {
@@ -243,8 +242,7 @@ trait NotifierAssertionsTrait
 
     protected function getNotificationEvents(): NotificationEvents
     {
-        // @phpstan-ignore if.alwaysFalse
-        if (version_compare(Kernel::VERSION, '6.2', '<')) {
+        if (!class_exists(NotificationEvents::class)) {
             Assert::fail('Notifier assertions require Symfony 6.2 or higher.');
         }
 


### PR DESCRIPTION
💡 What: Replaced dynamic `version_compare` check for `NotificationEvents` with a statically analyzable `class_exists` check in `NotifierAssertionsTrait`.
🎯 Why: Prevents PHPStan from flagging `if.alwaysFalse` when the installed Symfony version is statically known to be >= 6.2 based on composer dependencies. This allows us to remove the `@phpstan-ignore if.alwaysFalse` suppression, ensuring strict static analysis without friction.
🛠️ Tooling: Improves PHPStan analysis by removing suppression and relying on standard `class_exists` checks.

---
*PR created automatically by Jules for task [7335003563171624646](https://jules.google.com/task/7335003563171624646) started by @TavoNiievez*