### PR TITLE
🎨 Palette (DX): Refactor vague variable names

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,3 +1,14 @@
 ## 2024-04-14 - Rename mystery meat parameters for clarity
 **Learning:** Method parameters with vague, type-like names (e.g. `$mixed`, `$data`, `$value`) force developers to read the PHPDoc or function implementation to understand what is actually required. This increases cognitive load.
 **Action:** Always rename vague parameter names to descriptive ones that indicate their purpose or expected domain object (e.g. `$mixed` -> `$entityOrClass`), strictly improving code discoverability.
+## 2026-06-02 - Refactoring vague variable names
+**Learning:** Renaming parameters in public methods introduces a BC break for consumers using PHP 8+ named arguments.
+**Action:** Focus such DX refactoring strictly on private or protected methods where it is safe to do so.
+
+## 2026-06-02 - Statically analyzable version checks
+**Learning:** Using `version_compare` dynamically for runtime checks can trigger PHPStan errors (e.g., if.alwaysFalse) which might tempt developers to use .
+**Action:** Replace dynamic version checks with statically analyzable feature checks, like `class_exists()`, to satisfy strict analysis without suppressions.
+
+## 2026-06-02 - Statically analyzable version checks
+**Learning:** Using version_compare dynamically for runtime checks can trigger PHPStan errors (e.g., if.alwaysFalse) which might tempt developers to use phpstan-ignore.
+**Action:** Replace dynamic version checks with statically analyzable feature checks, like class_exists, to satisfy strict analysis without suppressions.

--- a/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
@@ -62,8 +62,8 @@ trait ConsoleAssertionsTrait
     {
         $options = [];
 
-        foreach ($parameters as $key => $value) {
-            $option = is_int($key) ? (string) $value : $key;
+        foreach ($parameters as $key => $parameterValue) {
+            $option = is_int($key) ? (string) $parameterValue : $key;
 
             match ($option) {
                 '--ansi'                 => $options['decorated'] = true,
@@ -73,7 +73,7 @@ trait ConsoleAssertionsTrait
                 '-v', '--verbose=1'      => $options['verbosity'] = OutputInterface::VERBOSITY_VERBOSE,
                 '-vv', '--verbose=2'     => $options['verbosity'] = OutputInterface::VERBOSITY_VERY_VERBOSE,
                 '-vvv', '--verbose=3'    => $options['verbosity'] = OutputInterface::VERBOSITY_DEBUG,
-                '--verbose'              => $options['verbosity'] = match ((int) $value) {
+                '--verbose'              => $options['verbosity'] = match ((int) $parameterValue) {
                     3       => OutputInterface::VERBOSITY_DEBUG,
                     2       => OutputInterface::VERBOSITY_VERY_VERBOSE,
                     default => OutputInterface::VERBOSITY_VERBOSE,

--- a/src/Codeception/Module/Symfony/FormAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/FormAssertionsTrait.php
@@ -214,11 +214,11 @@ trait FormAssertionsTrait
     /** @return array<string, mixed> */
     private function getRawCollectorData(FormDataCollector $collector): array
     {
-        $data = $collector->getData();
-        if ($data instanceof Data) {
-            $data = $data->getValue(true);
+        $collectorData = $collector->getData();
+        if ($collectorData instanceof Data) {
+            $collectorData = $collectorData->getValue(true);
         }
         /** @var array<string, mixed> */
-        return is_array($data) ? $data : [];
+        return is_array($collectorData) ? $collectorData : [];
     }
 }

--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -103,7 +103,7 @@ trait HttpClientAssertionsTrait
                 continue;
             }
 
-            $info = $this->extractValue($trace['info'] ?? []);
+            $info = $this->extractTraceData($trace['info'] ?? []);
             $infoUrl = is_array($info) ? ($info['url'] ?? $info['original_url'] ?? null) : null;
             if ($expectedUrl !== $infoUrl && $expectedUrl !== ($trace['url'] ?? null)) {
                 continue;
@@ -113,9 +113,9 @@ trait HttpClientAssertionsTrait
                 return true;
             }
 
-            $options = $this->extractValue($trace['options'] ?? []);
+            $options = $this->extractTraceData($trace['options'] ?? []);
             $options = is_array($options) ? $options : [];
-            if ($expectedBody !== null && $expectedBody !== $this->extractValue($options['body'] ?? $options['json'] ?? null)) {
+            if ($expectedBody !== null && $expectedBody !== $this->extractTraceData($options['body'] ?? $options['json'] ?? null)) {
                 continue;
             }
 
@@ -123,7 +123,7 @@ trait HttpClientAssertionsTrait
                 return true;
             }
 
-            $actualHeaders = $this->extractValue($options['headers'] ?? []);
+            $actualHeaders = $this->extractTraceData($options['headers'] ?? []);
             if (is_array($actualHeaders) && $expectedHeadersLower === array_intersect_key(array_change_key_case($actualHeaders), $expectedHeadersLower)) {
                 return true;
             }
@@ -145,13 +145,13 @@ trait HttpClientAssertionsTrait
         return $clientData['traces'];
     }
 
-    private function extractValue(mixed $value): mixed
+    private function extractTraceData(mixed $traceData): mixed
     {
         return match (true) {
-            $value instanceof Data => $value->getValue(true),
-            is_object($value) && method_exists($value, 'getValue') => $value->getValue(true),
-            $value instanceof Stringable => (string) $value,
-            default => $value,
+            $traceData instanceof Data => $traceData->getValue(true),
+            is_object($traceData) && method_exists($traceData, 'getValue') => $traceData->getValue(true),
+            $traceData instanceof Stringable => (string) $traceData,
+            default => $traceData,
         };
     }
 

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -243,8 +243,7 @@ trait NotifierAssertionsTrait
 
     protected function getNotificationEvents(): NotificationEvents
     {
-        // @phpstan-ignore if.alwaysFalse
-        if (version_compare(Kernel::VERSION, '6.2', '<')) {
+        if (!class_exists(NotificationLoggerListener::class)) {
             Assert::fail('Notifier assertions require Symfony 6.2 or higher.');
         }
 


### PR DESCRIPTION
💡 What: Renamed vague variable names like `$data` and `$value` to context-specific names in private methods (`$collectorData`, `$traceData`, `$parameterValue`), and removed a `@phpstan-ignore` suppression by replacing a dynamic version check with a statically analyzable `class_exists()` check.

🎯 Why: To reduce cognitive load and improve code self-documentation without introducing BC breaks on public methods. It also satisfies strict static analysis without relying on error suppressions.

🛠️ Tooling: Improves DX and PHPStan compatibility.

---
*PR created automatically by Jules for task [9207259621426543667](https://jules.google.com/task/9207259621426543667) started by @TavoNiievez*