### PR TITLE
🧹 [Code Health] Reduce nesting in Symfony connector rebooting logic

### DIFF
--- a/src/Codeception/Lib/Connector/Symfony.php
+++ b/src/Codeception/Lib/Connector/Symfony.php
@@ -53,11 +53,7 @@ class Symfony extends HttpKernelBrowser
      */
     public function rebootKernel(): void
     {
-        foreach ($this->persistentServices as $name => $_) {
-            if ($this->container->has($name)) {
-                $this->persistentServices[$name] = $this->container->get($name);
-            }
-        }
+        $this->updatePersistentServices();
 
         $this->persistDoctrineConnections();
 
@@ -68,15 +64,7 @@ class Symfony extends HttpKernelBrowser
 
         $this->container = $this->resolveContainer();
 
-        foreach ($this->persistentServices as $name => $service) {
-            try {
-                $this->container->set($name, $service);
-            } catch (InvalidArgumentException $e) {
-                if (function_exists('codecept_debug')) {
-                    codecept_debug("[Symfony] Can't set persistent service {$name}: {$e->getMessage()}");
-                }
-            }
-        }
+        $this->injectPersistentServices();
 
         $this->getProfiler()?->enable();
     }
@@ -115,5 +103,29 @@ class Symfony extends HttpKernelBrowser
                 unset($this->parameters['doctrine.connections']);
             }
         })->call($this->kernel->getContainer());
+    }
+
+    private function updatePersistentServices(): void
+    {
+        foreach ($this->persistentServices as $name => $_) {
+            if ($this->container->has($name)) {
+                $this->persistentServices[$name] = $this->container->get($name);
+            }
+        }
+    }
+
+    private function injectPersistentServices(): void
+    {
+        foreach ($this->persistentServices as $name => $service) {
+            try {
+                $this->container->set($name, $service);
+            } catch (InvalidArgumentException $e) {
+                if (!function_exists('codecept_debug')) {
+                    continue;
+                }
+
+                codecept_debug("[Symfony] Can't set persistent service {$name}: {$e->getMessage()}");
+            }
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** Extracted the deeply nested `foreach` loops in `rebootKernel()` into private `updatePersistentServices()` and `injectPersistentServices()` methods. Further reduced nesting inside `injectPersistentServices()` by using an early return (`continue`) when `codecept_debug` does not exist.
💡 **Why:** Refactoring the deeply nested code block inside the `rebootKernel` method of the Symfony connector significantly improves maintainability and readability without altering existing behavior.
✅ **Verification:** Verified by running the test suite (`vendor/bin/phpunit tests/`), running `phpstan` at max level, checking code style with `php-cs-fixer`, and confirming no regression during automated reviews.
✨ **Result:** Cleaned up `rebootKernel` while preserving existing logic exactly as it was.

---
*PR created automatically by Jules for task [15410907708824012987](https://jules.google.com/task/15410907708824012987) started by @TavoNiievez*