### PR TITLE
🧪 [testing improvement] Add unit tests for `_getEntityManager` in Symfony module

### DIFF
--- a/tests/SymfonyTest.php
+++ b/tests/SymfonyTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Codeception\Lib\Di;
+use Codeception\Lib\ModuleContainer;
+use Codeception\Module\Symfony;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+#[AllowMockObjectsWithoutExpectations]
+final class SymfonyTest extends TestCase
+{
+    public function testGetEntityManagerRetrievesFromContainerAndPersistsServices(): void
+    {
+        $di = new Di();
+        $moduleContainer = new ModuleContainer($di, []);
+        $module = new class($moduleContainer) extends Symfony {
+            public Container $containerMock;
+
+            public function _getContainer(): Container
+            {
+                return $this->containerMock;
+            }
+
+            /**
+             * @return array<non-empty-string, object>
+             */
+            public function getPermanentServices(): array
+            {
+                return $this->permanentServices;
+            }
+        };
+
+        $emMock = $this->createMock(EntityManagerInterface::class);
+        $doctrineMock = new \stdClass();
+        $defaultEmMock = new \stdClass();
+        $defaultConnectionMock = new \stdClass();
+
+        $container = new Container();
+        $container->set('doctrine.orm.entity_manager', $emMock);
+        $container->set('doctrine', $doctrineMock);
+        $container->set('doctrine.orm.default_entity_manager', $defaultEmMock);
+        $container->set('doctrine.dbal.default_connection', $defaultConnectionMock);
+
+        $module->containerMock = $container;
+
+        $em = $module->_getEntityManager();
+
+        $this->assertSame($emMock, $em);
+
+        $permanentServices = $module->getPermanentServices();
+        $this->assertArrayHasKey('doctrine.orm.entity_manager', $permanentServices);
+        $this->assertArrayHasKey('doctrine', $permanentServices);
+        $this->assertArrayHasKey('doctrine.orm.default_entity_manager', $permanentServices);
+        $this->assertArrayHasKey('doctrine.dbal.default_connection', $permanentServices);
+    }
+
+    public function testGetEntityManagerReturnsExistingServiceFromPermanentServices(): void
+    {
+        $di = new Di();
+        $moduleContainer = new ModuleContainer($di, []);
+        $module = new class($moduleContainer) extends Symfony {
+            /**
+             * @param non-empty-string $name
+             */
+            public function setPermanentService(string $name, object $service): void
+            {
+                $this->permanentServices[$name] = $service;
+            }
+        };
+
+        $emMock = $this->createMock(EntityManagerInterface::class);
+        $module->setPermanentService('doctrine.orm.entity_manager', $emMock);
+
+        $em = $module->_getEntityManager();
+
+        $this->assertSame($emMock, $em);
+    }
+
+    public function testGetEntityManagerFailsIfServiceNotInstanceOfEntityManagerInterface(): void
+    {
+        $di = new Di();
+        $moduleContainer = new ModuleContainer($di, []);
+        $module = new class($moduleContainer) extends Symfony {
+            public Container $containerMock;
+
+            public function _getContainer(): Container
+            {
+                return $this->containerMock;
+            }
+        };
+
+        $notEmService = new \stdClass();
+
+        $container = new Container();
+        $container->set('doctrine.orm.entity_manager', $notEmService);
+
+        $module->containerMock = $container;
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Service "doctrine.orm.entity_manager" is not an instance of EntityManagerInterface.');
+
+        $module->_getEntityManager();
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `_getEntityManager` method in `src/Codeception/Module/Symfony.php` lacked test coverage. A new test class `tests/SymfonyTest.php` has been introduced to cover its functionality using an anonymous class extending `Symfony` to inject mock container states and inspect internal behavior safely.

📊 **Coverage:** The test suite now explicitly covers three scenarios:
1. `testGetEntityManagerRetrievesFromContainerAndPersistsServices`: The "happy path" ensuring the service is fetched, properly typed, and related doctrine services are cached into `permanentServices`.
2. `testGetEntityManagerReturnsExistingServiceFromPermanentServices`: The cache-hit scenario verifying the method bypasses the container and immediately returns an already retrieved entity manager.
3. `testGetEntityManagerFailsIfServiceNotInstanceOfEntityManagerInterface`: The failure scenario validating that an assertion error is thrown when the retrieved service does not implement `EntityManagerInterface`.

✨ **Result:** Test coverage for `src/Codeception/Module/Symfony.php` is improved. The method is fully covered for correctness and regressions without requiring a full Codeception application boot, utilizing dependency mocks securely.

---
*PR created automatically by Jules for task [14073233845133179252](https://jules.google.com/task/14073233845133179252) started by @TavoNiievez*