### PR TITLE
🧹 [code health improvement] Remove deprecated seeEventTriggered and dontSeeEventTriggered methods

### DIFF
--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -58,25 +58,6 @@ trait EventsAssertionsTrait
     }
 
     /**
-     * Verifies that one or more event listeners were not called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->dontSeeEventTriggered('App\MyEvent');
-     * $I->dontSeeEventTriggered(new App\Events\MyEvent());
-     * $I->dontSeeEventTriggered(['App\MyEvent', 'App\MyOtherEvent']);
-     * ```
-     *
-     * @param      class-string|object|list<class-string|object> $expected
-     * @deprecated Use {@see dontSeeEventListenerIsCalled()} instead.
-     */
-    public function dontSeeEventTriggered(array|object|string $expected): void
-    {
-        trigger_error('dontSeeEventTriggered is deprecated, please use dontSeeEventListenerIsCalled instead', E_USER_DEPRECATED);
-        $this->dontSeeEventListenerIsCalled($expected);
-    }
-
-    /**
      * Verifies that there were no orphan events during the test.
      *
      * An orphan event is an event that was triggered by manually executing the
@@ -130,25 +111,6 @@ trait EventsAssertionsTrait
     public function seeEventListenerIsCalled(array|object|string $expected, array|string $events = []): void
     {
         $this->assertListenerCalled($expected, $events, shouldBeCalled: true);
-    }
-
-    /**
-     * Verifies that one or more event listeners were called during the test.
-     *
-     * ```php
-     * <?php
-     * $I->seeEventTriggered('App\MyEvent');
-     * $I->seeEventTriggered(new App\Events\MyEvent());
-     * $I->seeEventTriggered(['App\MyEvent', 'App\MyOtherEvent']);
-     * ```
-     *
-     * @param class-string|object|list<class-string|object> $expected
-     * @deprecated Use {@see seeEventListenerIsCalled()} instead.
-     */
-    public function seeEventTriggered(array|object|string $expected): void
-    {
-        trigger_error('seeEventTriggered is deprecated, please use seeEventListenerIsCalled instead', E_USER_DEPRECATED);
-        $this->seeEventListenerIsCalled($expected);
     }
 
     /**

--- a/tests/EventsAssertionsTest.php
+++ b/tests/EventsAssertionsTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests;
 
 use Codeception\Module\Symfony\EventsAssertionsTrait;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Component\HttpKernel\Kernel;
 use Tests\App\Event\TestEvent;
 use Tests\App\Listener\TestEventListener;
@@ -25,13 +24,6 @@ final class EventsAssertionsTest extends CodeceptTestCase
     {
         $this->client->request('GET', '/dispatch-orphan-event');
         $this->dontSeeEventListenerIsCalled(TestEventListener::class);
-    }
-
-    #[IgnoreDeprecations]
-    public function testDontSeeEventTriggered(): void
-    {
-        $this->client->request('GET', '/dispatch-orphan-event');
-        $this->dontSeeEventTriggered(TestEventListener::class);
     }
 
     public function testDontSeeOrphanEvent(): void
@@ -56,13 +48,6 @@ final class EventsAssertionsTest extends CodeceptTestCase
 
         $this->client->request('GET', '/dispatch-named-event');
         $this->seeEventListenerIsCalled(TestEventListener::class, 'named.event');
-    }
-
-    #[IgnoreDeprecations]
-    public function testSeeEventTriggered(): void
-    {
-        $this->client->request('GET', '/dispatch-event');
-        $this->seeEventTriggered(TestEventListener::class);
     }
 
     public function testSeeOrphanEvent(): void


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `seeEventTriggered` and `dontSeeEventTriggered` methods from `EventsAssertionsTrait`, as well as their corresponding tests.

💡 **Why:** These methods have been deprecated. Removing them cleans up the codebase and enforces the usage of the newer, more explicit methods (`seeEventListenerIsCalled` and `dontSeeEventListenerIsCalled`). This is part of general code health improvements to remove deprecated legacy code.

✅ **Verification:** 
- Ensured the methods were fully removed.
- Tests that explicitly exercised these methods were removed. 
- Passed PHPUnit test suite.
- Passed PHPStan static analysis.
- Passed PHP CS Fixer check.

✨ **Result:** A cleaner codebase with less legacy methods floating around.

---
*PR created automatically by Jules for task [9477658354419475563](https://jules.google.com/task/9477658354419475563) started by @TavoNiievez*