### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -246,12 +246,15 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
      */
     public function _after(TestInterface $test): void
     {
-        foreach ($this->permanentServices as $serviceName => $_) {
-            $service = $this->getService($serviceName);
-            if (is_object($service)) {
-                $this->permanentServices[$serviceName] = $service;
-            } else {
-                unset($this->permanentServices[$serviceName]);
+        if ($this->permanentServices !== []) {
+            $container = $this->_getContainer();
+            foreach ($this->permanentServices as $serviceName => $_) {
+                $service = $container->has($serviceName) ? $container->get($serviceName) : null;
+                if (is_object($service)) {
+                    $this->permanentServices[$serviceName] = $service;
+                } else {
+                    unset($this->permanentServices[$serviceName]);
+                }
             }
         }
         $this->persistentServices = [];


### PR DESCRIPTION
💡 What: Lift the dependency injection container lookup out of the loop in `_after` method.
🎯 Why: Iteratively calling `getService()` triggers `_getContainer()` internally for every iteration, which repeats a check for the `test.service_container` alias. Retrieving the container once prevents multiple evaluations.
📊 Impact: Reduces overhead associated with repeated kernel and container access during the test tear-down phase for tests using multiple permanent services.
🔬 Measurement: Run unit tests to verify identical tear-down functionality and zero regressions in subsequent tests.

---
*PR created automatically by Jules for task [13774113448152747754](https://jules.google.com/task/13774113448152747754) started by @TavoNiievez*