### PR TITLE
🎨 Palette (DX): Add custom InvalidSessionAttributeException

### DIFF
--- a/src/Codeception/Module/Symfony/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Module/Symfony/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Module\Symfony\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException {}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Module\Symfony\Exception\InvalidSessionAttributeException;
 use InvalidArgumentException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
@@ -173,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedValueOrAttribute)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedValueOrAttribute)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedValueOrAttribute)));
             }
             $this->assertTrue($session->has($expectedValueOrAttribute), "No session attribute with name '{$expectedValueOrAttribute}'");
         }

--- a/tests/SessionAssertionsTest.php
+++ b/tests/SessionAssertionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use Codeception\Module\Symfony\Exception\InvalidSessionAttributeException;
 use Codeception\Module\Symfony\SessionAssertionsTrait;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 use Tests\App\Entity\User;
@@ -82,6 +83,13 @@ final class SessionAssertionsTest extends CodeceptTestCase
         $this->initSession(['key1' => 'value1', 'key2' => 'value2']);
         $this->seeSessionHasValues(['key1', 'key2']);
         $this->seeSessionHasValues(['key1' => 'value1', 'key2' => 'value2']);
+    }
+
+    public function testSeeSessionHasValuesThrowsException(): void
+    {
+        $this->expectException(InvalidSessionAttributeException::class);
+        $this->expectExceptionMessage('Attribute name must be string, int given.');
+        $this->seeSessionHasValues([1]);
     }
 
     private function getTestUser(): User


### PR DESCRIPTION
💡 What: Replaced the generic `InvalidArgumentException` in `SessionAssertionsTrait::seeSessionHasValues` with a custom, domain-specific `InvalidSessionAttributeException`.
🎯 Why: This custom exception clearly distinguishes test configuration errors (passing non-strings to the session values assertion) from other generic application-level argument exceptions, reducing cognitive load when diagnosing failing test output.
🛠️ Tooling: Enhances IDE discoverability for testing exceptions and provides a dedicated exception namespace for Codeception Symfony module errors.

---
*PR created automatically by Jules for task [7623309364507737851](https://jules.google.com/task/7623309364507737851) started by @TavoNiievez*