### PR TITLE
⚡ Bolt: Optimize event counting in Symfony debug collectors

### DIFF
--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -456,12 +456,12 @@ class Symfony extends Framework implements DoctrineProvider, PartedModule
 
     private function debugMailerData(MessageDataCollector $messageCollector): void
     {
-        $this->debugSection('Emails', sprintf('%d sent', count($messageCollector->getEvents()->getMessages())));
+        $this->debugSection('Emails', sprintf('%d sent', count($messageCollector->getEvents()->getEvents())));
     }
 
     private function debugNotifierData(NotificationDataCollector $notificationCollector): void
     {
-        $this->debugSection('Notifications', sprintf('%d sent', count($notificationCollector->getEvents()->getMessages())));
+        $this->debugSection('Notifications', sprintf('%d sent', count($notificationCollector->getEvents()->getEvents())));
     }
 
     private function debugTimeData(TimeDataCollector $timeCollector): void


### PR DESCRIPTION
💡 What: The optimization replaces `count($collector->getEvents()->getMessages())` with `count($collector->getEvents()->getEvents())` inside `debugMailerData` and `debugNotifierData` in `src/Codeception/Module/Symfony.php`.

🎯 Why: The `getMessages()` method on Symfony's `MessageEvents` and `NotificationEvents` iterates over the internal events to construct and return a new array of messages. This causes unnecessary O(N) memory allocation and processing overhead just to get a count. Using `getEvents()` directly exposes the internal array, allowing `count()` to execute in O(1) time without extra memory allocation.

📊 Impact: Reduces array allocation overhead from O(N) to O(1) during debug logging of sent emails and notifications.

🔬 Measurement: Run the test suite using `vendor/bin/phpunit tests/` to ensure no functionality is broken. No behavior changes, only a memory/execution time micro-optimization.

---
*PR created automatically by Jules for task [11847691207799938494](https://jules.google.com/task/11847691207799938494) started by @TavoNiievez*