### PR TITLE
🎨 Palette (DX): Improve type hints for routing parameters

### DIFF
--- a/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/RouterAssertionsTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codeception\Module\Symfony;
 
 use PHPUnit\Framework\Assert;
+use Stringable;
 use Symfony\Component\Routing\RouterInterface;
 
 use function array_intersect_key;
@@ -25,7 +26,7 @@ trait RouterAssertionsTrait
      * $I->amOnAction('ArticleController', ['slug' => 'lorem-ipsum']);
      * ```
      *
-     * @param array<non-empty-string, mixed> $params
+     * @param array<non-empty-string, scalar|Stringable|array<mixed>|null> $params
      */
     public function amOnAction(string $action, array $params = []): void
     {
@@ -41,7 +42,7 @@ trait RouterAssertionsTrait
      * $I->amOnRoute('posts.show', ['id' => 34]);
      * ```
      *
-     * @param array<string, mixed> $params
+     * @param array<string, scalar|Stringable|array<mixed>|null> $params
      */
     public function amOnRoute(string $routeName, array $params = []): void
     {
@@ -85,7 +86,7 @@ trait RouterAssertionsTrait
      * $I->seeCurrentRouteIs('posts.show', ['id' => 8]);
      * ```
      *
-     * @param array<string, mixed> $params
+     * @param array<string, scalar|Stringable|array<mixed>|null> $params
      */
     public function seeCurrentRouteIs(string $routeName, array $params = []): void
     {
@@ -157,7 +158,7 @@ trait RouterAssertionsTrait
         );
     }
 
-    /** @param array<string, mixed> $params */
+    /** @param array<string, scalar|Stringable|array<mixed>|null> $params */
     private function openRoute(string $routeName, array $params = []): void
     {
         $this->getClient()->request('GET', $this->grabRouterService()->generate($routeName, $params));


### PR DESCRIPTION
💡 What: Updated the vague `@param array<string, mixed>` to the precise `@param array<string, scalar|Stringable|array<mixed>|null>` for routing parameters (`$params`) in `RouterAssertionsTrait`.
🎯 Why: Symfony routing validly accepts scalars, stringables, arrays (for query strings), and null (for default omission) as route parameters. The generic `mixed` type prevents IDEs and static analysis from catching invalid types (like complex entities).
🛠️ Tooling: Improves PHPStan analysis and IDE autocompletion by accurately reflecting legitimate values while enforcing type safety. Imported the `Stringable` interface to ensure clean PHPDoc declarations.

---
*PR created automatically by Jules for task [13717218275023062009](https://jules.google.com/task/13717218275023062009) started by @TavoNiievez*