### PR TITLE
⚡ Bolt: Optimize Message and Notification Event retrieval for O(1) performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,2 @@
+### 2026-06-05: `getEvents()` vs `getMessages()` in Symfony Mailer/Notifier Collectors
+**Learning:** When retrieving events from Symfony's `MessageEvents` or `NotificationEvents` (e.g. `$this->getMessageMailerEvents()`), calling `getMessages()` creates a new array by iterating over all events (O(N) operation). If you only need to check the last event, count the events, or fetch an event by a specific index, use `getEvents()` instead. It returns the internal array directly (O(1) operation), avoiding unnecessary memory allocation.

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -102,10 +102,16 @@ trait MailerAssertionsTrait
      */
     public function grabLastSentEmail(): ?Email
     {
-        /** @var Email[] $emails */
-        $emails = $this->getMessageMailerEvents()->getMessages();
+        $events = $this->getMessageMailerEvents()->getEvents();
 
-        return $emails ? $emails[array_key_last($emails)] : null;
+        if ($events === []) {
+            return null;
+        }
+
+        /** @var Email $email */
+        $email = $events[array_key_last($events)]->getMessage();
+
+        return $email;
     }
 
     /**

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -163,9 +163,13 @@ trait NotifierAssertionsTrait
      */
     public function grabLastSentNotification(): ?MessageInterface
     {
-        $notifications = $this->getNotifierMessages();
+        $events = $this->getNotifierEvents();
 
-        return $notifications ? $notifications[array_key_last($notifications)] : null;
+        if ($events === []) {
+            return null;
+        }
+
+        return $events[array_key_last($events)]->getMessage();
     }
 
     /**
@@ -238,7 +242,9 @@ trait NotifierAssertionsTrait
      */
     public function getNotifierMessage(int $index = 0, ?string $transportName = null): ?MessageInterface
     {
-        return $this->getNotifierMessages($transportName)[$index] ?? null;
+        $event = $this->getNotifierEvents($transportName)[$index] ?? null;
+
+        return $event ? $event->getMessage() : null;
     }
 
     protected function getNotificationEvents(): NotificationEvents


### PR DESCRIPTION
💡 What:
Replaced calls to `getMessages()` and `getNotifierMessages()` with `getEvents()` and `getNotifierEvents()` respectively in `grabLastSentEmail()`, `grabLastSentNotification()`, and `getNotifierMessage()`.

🎯 Why:
In Symfony's `MessageEvents` and `NotificationEvents`, calling `getMessages()` forces an iteration over all events to instantiate a new array of messages (O(N) operation). When only fetching a specific index or the last element, calling `getEvents()` provides direct O(1) access to the internal array, bypassing unnecessary memory allocation and processing.

📊 Impact:
Improves execution speed and reduces memory overhead when retrieving emails/notifications, specifically avoiding large array copies when test suites generate multiple messages.

🔬 Measurement:
Run the full test suite (`vendor/bin/phpunit`) to confirm all assertions still pass and memory behavior is improved.

---
*PR created automatically by Jules for task [7212848588245267748](https://jules.google.com/task/7212848588245267748) started by @TavoNiievez*