### PR TITLE
🎨 Palette (DX): Replace generic InvalidArgumentException with descriptive custom exception

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - [Add Custom Exception to replace generic one]
+**Learning:** [Generic \InvalidArgumentException thrown on type check failure instead of descriptive exception]
+**Action:** [Create a custom `InvalidSessionAttributeException` class and use it in `SessionAssertionsTrait::seeSessionHasValues` when an invalid attribute name type is provided.]

--- a/src/Codeception/Module/Symfony/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Module/Symfony/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Module\Symfony\Exception;
+
+use InvalidArgumentException;
+
+use function get_debug_type;
+use function sprintf;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+    public static function fromInvalidType(mixed $value): self
+    {
+        return new self(sprintf('Attribute name must be string, %s given.', get_debug_type($value)));
+    }
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Module\Symfony\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw InvalidSessionAttributeException::fromInvalidType($expectedAttr);
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Replaced the generic `\InvalidArgumentException` with a custom `InvalidSessionAttributeException` in `SessionAssertionsTrait`.
🎯 Why: It reduces cognitive load by providing a clear, contextual exception specifically for when an invalid session attribute name type is passed, rather than a generic argument error that can be hard to track down.
🛠️ Tooling: Improved type safety and developer experience, ensuring PHPStan (level 8) passes flawlessly while maintaining exact backward compatibility by extending `\InvalidArgumentException`.

---
*PR created automatically by Jules for task [8535808193458642189](https://jules.google.com/task/8535808193458642189) started by @TavoNiievez*