### PR TITLE
🎨 Palette (DX): Replace dynamic version check with class_exists

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - [Title]
+**Learning:** [DX insight/Constraint]
+**Action:** [How to apply next time]

--- a/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/NotifierAssertionsTrait.php
@@ -6,7 +6,6 @@ namespace Codeception\Module\Symfony;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\LogicalNot;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Event\NotificationEvents;
 use Symfony\Component\Notifier\EventListener\NotificationLoggerListener;
@@ -14,7 +13,7 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Test\Constraint as NotifierConstraint;
 
 use function array_key_last;
-use function version_compare;
+use function class_exists;
 
 trait NotifierAssertionsTrait
 {
@@ -249,8 +248,7 @@ trait NotifierAssertionsTrait
 
     protected function getNotificationEvents(): NotificationEvents
     {
-        // @phpstan-ignore if.alwaysFalse
-        if (version_compare(Kernel::VERSION, '6.2', '<')) {
+        if (!class_exists(NotificationEvents::class)) {
             Assert::fail('Notifier assertions require Symfony 6.2 or higher.');
         }
 


### PR DESCRIPTION
💡 **What:** 
Replaced a dynamic `version_compare(Kernel::VERSION, ...)` check in `NotifierAssertionsTrait` with a statically analyzable `class_exists(NotificationEvents::class)` check. 
Removed the `@phpstan-ignore if.alwaysFalse` comment and cleaned up unused imports (`Kernel` and `version_compare`).

🎯 **Why:** 
The codebase strictly prohibits `@phpstan-ignore` annotations. By using a feature-detection approach (`class_exists`) rather than a version-string comparison, PHPStan correctly infers that the condition is dynamic and not always false. This makes the code more robust, inherently type-safe, and removes the need for suppression comments, reducing cognitive load and brittle checks.

🛠️ **Tooling:** 
This improves PHPStan integration by resolving the `if.alwaysFalse` error natively without requiring suppression, keeping the analysis strict and reliable.

---
*PR created automatically by Jules for task [11185245626506820546](https://jules.google.com/task/11185245626506820546) started by @TavoNiievez*