### PR TITLE
🎨 Palette (DX): Refactor vague `$function` variable to `$callingFunction`

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-06-15 - [Refactor vague variable names]
+**Learning:** Avoid using the variable name `$function` for string variables that represent a function name, as it can cause cognitive confusion with PHP's `callable` pseudo-type or anonymous functions. Prefer context-specific names like `$callingFunction`.
+**Action:** Rename `$function` to `$callingFunction` in HttpClientAssertionsTrait.

--- a/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/EventsAssertionsTrait.php
@@ -297,8 +297,8 @@ trait EventsAssertionsTrait
         return 'event_dispatcher';
     }
 
-    protected function grabEventCollector(string $function): EventDataCollector
+    protected function grabEventCollector(string $callingFunction): EventDataCollector
     {
-        return $this->grabCollector(DataCollectorName::EVENTS, $function);
+        return $this->grabCollector(DataCollectorName::EVENTS, $callingFunction);
     }
 }

--- a/src/Codeception/Module/Symfony/FormAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/FormAssertionsTrait.php
@@ -175,14 +175,14 @@ trait FormAssertionsTrait
         $this->assertGreaterThan(0, $this->getFormErrorsCount(__FUNCTION__), 'Expecting that the form has errors, but there were none!');
     }
 
-    protected function grabFormCollector(string $function): FormDataCollector
+    protected function grabFormCollector(string $callingFunction): FormDataCollector
     {
-        return $this->grabCollector(DataCollectorName::FORM, $function);
+        return $this->grabCollector(DataCollectorName::FORM, $callingFunction);
     }
 
-    private function getFormErrorsCount(string $function): int
+    private function getFormErrorsCount(string $callingFunction): int
     {
-        $collector = $this->grabFormCollector($function);
+        $collector = $this->grabFormCollector($callingFunction);
         $rawData = $this->getRawCollectorData($collector);
 
         return isset($rawData['nb_errors']) && is_numeric($rawData['nb_errors']) ? (int) $rawData['nb_errors'] : 0;

--- a/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpClientAssertionsTrait.php
@@ -90,14 +90,14 @@ trait HttpClientAssertionsTrait
      */
     private function hasHttpClientRequest(
         string $httpClientId,
-        string $function,
+        string $callingFunction,
         string $expectedUrl,
         string $expectedMethod,
         string|array|null $expectedBody = null,
         array $expectedHeaders = []
     ): bool {
         $expectedHeadersLower = $expectedHeaders === [] ? [] : array_change_key_case($expectedHeaders);
-        $traces = $this->getHttpClientTraces($httpClientId, $function);
+        $traces = $this->getHttpClientTraces($httpClientId, $callingFunction);
 
         foreach ($traces as $trace) {
             if (!is_array($trace) || ($trace['method'] ?? null) !== $expectedMethod) {
@@ -138,9 +138,9 @@ trait HttpClientAssertionsTrait
     }
 
     /** @return array<mixed> */
-    private function getHttpClientTraces(string $httpClientId, string $function): array
+    private function getHttpClientTraces(string $httpClientId, string $callingFunction): array
     {
-        $clients = $this->grabHttpClientCollector($function)->getClients();
+        $clients = $this->grabHttpClientCollector($callingFunction)->getClients();
         if (!isset($clients[$httpClientId]) || !is_array($clients[$httpClientId])) {
             Assert::fail(sprintf('HttpClient "%s" is not registered.', $httpClientId));
         }
@@ -160,8 +160,8 @@ trait HttpClientAssertionsTrait
         };
     }
 
-    protected function grabHttpClientCollector(string $function): HttpClientDataCollector
+    protected function grabHttpClientCollector(string $callingFunction): HttpClientDataCollector
     {
-        return $this->grabCollector(DataCollectorName::HTTP_CLIENT, $function);
+        return $this->grabCollector(DataCollectorName::HTTP_CLIENT, $callingFunction);
     }
 }

--- a/src/Codeception/Module/Symfony/HttpKernelAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/HttpKernelAssertionsTrait.php
@@ -45,16 +45,16 @@ trait HttpKernelAssertionsTrait
      *     )))))))))
      * )
      */
-    protected function grabCollector(DataCollectorName $name, string $function = '', ?string $message = null): DataCollectorInterface
+    protected function grabCollector(DataCollectorName $name, string $callingFunction = '', ?string $message = null): DataCollectorInterface
     {
         $profile = $this->getProfile();
 
         if ($profile === null) {
-            Assert::fail(sprintf("The Profile is needed to use the '%s' function.", $function));
+            Assert::fail(sprintf("The Profile is needed to use the '%s' function.", $callingFunction));
         }
 
         if (!$profile->hasCollector($name->value)) {
-            Assert::fail($message ?: sprintf("The '%s' collector is needed to use the '%s' function.", $name->value, $function));
+            Assert::fail($message ?: sprintf("The '%s' collector is needed to use the '%s' function.", $name->value, $callingFunction));
         }
 
         return $profile->getCollector($name->value);

--- a/src/Codeception/Module/Symfony/LoggerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/LoggerAssertionsTrait.php
@@ -57,8 +57,8 @@ trait LoggerAssertionsTrait
         $this->assertEmpty($foundDeprecations, $errorMessage);
     }
 
-    protected function grabLoggerCollector(string $function): LoggerDataCollector
+    protected function grabLoggerCollector(string $callingFunction): LoggerDataCollector
     {
-        return $this->grabCollector(DataCollectorName::LOGGER, $function);
+        return $this->grabCollector(DataCollectorName::LOGGER, $callingFunction);
     }
 }

--- a/src/Codeception/Module/Symfony/MimeAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MimeAssertionsTrait.php
@@ -169,12 +169,12 @@ trait MimeAssertionsTrait
     /**
      * Returns the last email sent if $email is null. If no email has been sent it fails.
      */
-    private function verifyEmailObject(?Email $email, string $function): Email
+    private function verifyEmailObject(?Email $email, string $callingFunction): Email
     {
         $email = $email ?: $this->grabLastSentEmail();
         $errorMsgTemplate = "There is no email to verify. An Email object was not specified when invoking '%s' and the application has not sent one.";
         return $email ?? Assert::fail(
-            sprintf($errorMsgTemplate, $function)
+            sprintf($errorMsgTemplate, $callingFunction)
         );
     }
 }

--- a/src/Codeception/Module/Symfony/TimeAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/TimeAssertionsTrait.php
@@ -44,8 +44,8 @@ trait TimeAssertionsTrait
         );
     }
 
-    protected function grabTimeCollector(string $function): TimeDataCollector
+    protected function grabTimeCollector(string $callingFunction): TimeDataCollector
     {
-        return $this->grabCollector(DataCollectorName::TIME, $function);
+        return $this->grabCollector(DataCollectorName::TIME, $callingFunction);
     }
 }

--- a/src/Codeception/Module/Symfony/TranslationAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/TranslationAssertionsTrait.php
@@ -171,8 +171,8 @@ trait TranslationAssertionsTrait
         );
     }
 
-    protected function grabTranslationCollector(string $function): TranslationDataCollector
+    protected function grabTranslationCollector(string $callingFunction): TranslationDataCollector
     {
-        return $this->grabCollector(DataCollectorName::TRANSLATION, $function);
+        return $this->grabCollector(DataCollectorName::TRANSLATION, $callingFunction);
     }
 }

--- a/src/Codeception/Module/Symfony/TwigAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/TwigAssertionsTrait.php
@@ -76,8 +76,8 @@ trait TwigAssertionsTrait
         );
     }
 
-    protected function grabTwigCollector(string $function): TwigDataCollector
+    protected function grabTwigCollector(string $callingFunction): TwigDataCollector
     {
-        return $this->grabCollector(DataCollectorName::TWIG, $function);
+        return $this->grabCollector(DataCollectorName::TWIG, $callingFunction);
     }
 }


### PR DESCRIPTION
💡 What: Renamed the parameter `$function` to `$callingFunction` across all Codeception Symfony module assertion traits where it is used to pass the calling function's name to the data collector.

🎯 Why: Using the variable name `$function` for a string variable that represents a function name causes cognitive confusion with PHP's `callable` pseudo-type or anonymous functions. Renaming it to `$callingFunction` makes the code self-documenting and reduces cognitive load without changing any business logic.

🛠️ Tooling: Improves clarity for developers reading the internal helper methods. Tested via `vendor/bin/phpstan analyse src --level=max` (0 errors) and `vendor/bin/phpunit tests/` (100% passing).

---
*PR created automatically by Jules for task [7677699072547757921](https://jules.google.com/task/7677699072547757921) started by @TavoNiievez*