### PR TITLE
🎨 Palette (DX): Custom exception for invalid session attributes

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,3 +1,7 @@
 ## 2024-06-15 - [Refactor vague variable names]
 **Learning:** Avoid using the variable name `$function` for string variables that represent a function name, as it can cause cognitive confusion with PHP's `callable` pseudo-type or anonymous functions. Prefer context-specific names like `$callingFunction`.
 **Action:** Rename `$function` to `$callingFunction` in HttpClientAssertionsTrait.
+
+## 2024-06-17 - [Custom Exception for better DX]
+**Learning:** Generic exceptions like `InvalidArgumentException` make it hard to pinpoint the exact failure in tests. Replacing them with context-specific exceptions like `InvalidSessionAttributeException` reduces debugging time and cognitive load.
+**Action:** When a generic exception is thrown to indicate a specific domain error (e.g. invalid type for a session attribute), introduce a well-named custom exception extending the generic one.

--- a/src/Codeception/Module/Symfony/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Module/Symfony/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Module\Symfony\Exception;
+
+use InvalidArgumentException;
+use Throwable;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+    public function __construct(string $type, int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct(
+            sprintf('Attribute name must be string, %s given.', $type),
+            $code,
+            $previous
+        );
+    }
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Module\Symfony\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -23,7 +23,6 @@ use function get_debug_type;
 use function is_int;
 use function is_string;
 use function serialize;
-use function sprintf;
 
 trait SessionAssertionsTrait
 {
@@ -174,7 +173,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(get_debug_type($expectedAttr));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Replaced the generic `InvalidArgumentException` with a specific `InvalidSessionAttributeException` in `SessionAssertionsTrait`.

🎯 Why: When an invalid type is passed as a session attribute name (e.g. to `seeSessionHasValues`), failing with a generic exception makes it hard to distinguish from other invalid arguments. Using a custom exception makes the error's origin and meaning instantly discoverable.

🛠️ Tooling: Improved type clarity without breaking existing catch blocks since it extends `InvalidArgumentException`. Cleaned up unused imports in the trait.

---
*PR created automatically by Jules for task [14638879822515162835](https://jules.google.com/task/14638879822515162835) started by @TavoNiievez*