### PR TITLE
⚡ Bolt: Optimize grabLastSentRawMessage to avoid O(N) memory allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,6 @@
+## 2024-06-17 - Initial Bolt File
+**Learning:** This file tracks Bolt's crucial performance learnings to help optimize this specific codebase over time.
+**Action:** Consult this list before proposing optimizations.
+## 2024-06-17 - Avoid O(N) allocation with getMessages()
+**Learning:** Calling `$events->getMessages()` in Symfony's `MessageEvents` or `NotificationEvents` creates and returns a new array every time.
+**Action:** When you only need the count, or a specific item (like the last one), use `$events->getEvents()` instead. It returns the internal array directly (O(1) allocation) rather than allocating a new array containing all items (O(N) allocation).

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -160,9 +160,9 @@ trait MailerAssertionsTrait
 
     protected function grabLastSentRawMessage(): ?RawMessage
     {
-        $messages = $this->getMessageMailerEvents()->getMessages();
+        $events = $this->getMessageMailerEvents()->getEvents();
 
-        return $messages ? $messages[array_key_last($messages)] : null;
+        return $events ? $events[array_key_last($events)]->getMessage() : null;
     }
 
     protected function getMessageMailerEvents(): MessageEvents


### PR DESCRIPTION
💡 What: Refactored `grabLastSentRawMessage` in `MailerAssertionsTrait` to use `getEvents()` instead of `getMessages()` when fetching the last sent email message.

🎯 Why: Calling `$events->getMessages()` in Symfony's `MessageEvents` maps over the events and allocates a new array containing all messages (O(N)). Since `grabLastSentRawMessage` only needs the last message, doing this array allocation is wasteful. By fetching the raw events array (which is returned in O(1) without allocation) and extracting the message from the last event, we avoid the overhead.

📊 Impact: Avoids unnecessary O(N) array allocation and iteration when testing with multiple sent emails, improving test performance and reducing memory usage.

🔬 Measurement: Run the PHPUnit test suite. The existing tests in `Codeception/Module/Symfony` verify the mailer assertions function exactly as expected.

---
*PR created automatically by Jules for task [9038374341573478220](https://jules.google.com/task/9038374341573478220) started by @TavoNiievez*