### PR TITLE
⚡ Bolt: Optimize grabLastSentRawMessage memory allocation

### DIFF
--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -160,9 +160,9 @@ trait MailerAssertionsTrait
 
     protected function grabLastSentRawMessage(): ?RawMessage
     {
-        $messages = $this->getMessageMailerEvents()->getMessages();
+        $events = $this->getMessageMailerEvents()->getEvents();
 
-        return $messages ? $messages[array_key_last($messages)] : null;
+        return $events ? $events[array_key_last($events)]->getMessage() : null;
     }
 
     protected function getMessageMailerEvents(): MessageEvents


### PR DESCRIPTION
💡 **What**: Refactored `grabLastSentRawMessage` to use `getEvents()` and extract the message only from the last event instead of calling `getMessages()`.
🎯 **Why**: When there are many sent emails, calling `getMessages()` triggers O(N) memory allocation and loop processing overhead just to discard all but the last item. `getEvents()` returns the internal array directly in O(1) time.
📊 **Impact**: Reduces memory allocation and execution time when retrieving the last sent email, especially when a large number of emails have been sent during the test cycle.
🔬 **Measurement**: Verified by analyzing the difference in execution time using microtime testing for large arrays, showing a near instant O(1) lookup vs O(N) linear time processing.

---
*PR created automatically by Jules for task [14991415436840825076](https://jules.google.com/task/14991415436840825076) started by @TavoNiievez*