### PR TITLE
⚡ Bolt: Optimize grabLastSentRawMessage to prevent O(N) memory allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Optimize O(N) array allocation in Symfony Data Collectors
+**Learning:** Calling `getMessages()` on Symfony's `MessageEvents` or `NotificationEvents` triggers an iteration over all events to construct a new array of messages. When you only need to retrieve a specific event or count them, this creates unnecessary O(N) memory allocation and overhead.
+**Action:** Use `getEvents()` to access the internal array directly for O(1) lookups or operations that don't strictly require an array of mapped messages.

--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -160,9 +160,9 @@ trait MailerAssertionsTrait
 
     protected function grabLastSentRawMessage(): ?RawMessage
     {
-        $messages = $this->getMessageMailerEvents()->getMessages();
+        $events = $this->getMessageMailerEvents()->getEvents();
 
-        return $messages ? $messages[array_key_last($messages)] : null;
+        return $events ? $events[array_key_last($events)]->getMessage() : null;
     }
 
     protected function getMessageMailerEvents(): MessageEvents


### PR DESCRIPTION
💡 What: Changed `grabLastSentRawMessage()` to retrieve the last message via `getEvents()` instead of `getMessages()`.
🎯 Why: `MessageEvents::getMessages()` performs an O(N) iteration mapping over all events to construct an array of messages. When we only need the last message, this instantiates an entire array unnecessarily. `getEvents()` simply returns the internal array, allowing an O(1) lookup.
📊 Impact: Prevents an O(N) array allocation overhead when retrieving the last sent email, which optimizes memory usage and speed when multiple emails are sent.
🔬 Measurement: Verify using `vendor/bin/phpunit tests/` to ensure no functionality is broken. Check memory footprint when retrieving the last email from a large number of dispatched emails.

---
*PR created automatically by Jules for task [2727343647779082086](https://jules.google.com/task/2727343647779082086) started by @TavoNiievez*