### PR TITLE
🎨 Palette (DX): Replace generic InvalidArgumentException with InvalidSessionAttributeException

### DIFF
--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: The DX enhancement added.
Created a custom `InvalidSessionAttributeException` and used it in `SessionAssertionsTrait::seeSessionHasValues` instead of a generic `InvalidArgumentException`.

🎯 Why: How it reduces cognitive load or prevents bugs.
It makes the error source immediately obvious without needing to read the exception message, reducing cognitive load when tests fail due to invalid input types.

🛠️ Tooling: If it improves PHPStan/IDE support.
Improves code clarity and IDE error tracing.

---
*PR created automatically by Jules for task [6942918683238581095](https://jules.google.com/task/6942918683238581095) started by @TavoNiievez*