### PR TITLE
🎨 Palette (DX): Replace generic exception with InvalidSessionAttributeException

### DIFF
--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException {}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Replaced the generic `InvalidArgumentException` thrown when a non-string session attribute name is provided in `SessionAssertionsTrait::seeSessionHasValues` with a custom `InvalidSessionAttributeException`.
🎯 Why: It reduces cognitive load by providing a specific exception that explicitly indicates the context of the error (an invalid session attribute type), rather than a generic invalid argument exception. This aligns with the principles of making errors clearer and more descriptive.
🛠️ Tooling: Improves static analysis and IDE support by utilizing domain-specific exceptions.

---
*PR created automatically by Jules for task [16179986677850065957](https://jules.google.com/task/16179986677850065957) started by @TavoNiievez*