### PR TITLE
🎨 Palette (DX): Replace generic InvalidArgumentException with custom InvalidSessionAttributeException

### DIFF
--- a/src/Codeception/Module/Symfony/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Module/Symfony/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Module\Symfony\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException {}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Module\Symfony\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Replaced the generic `InvalidArgumentException` thrown in `SessionAssertionsTrait::seeSessionHasValues` when an invalid attribute name is provided with a custom, explicitly named `InvalidSessionAttributeException`.
🎯 Why: A custom exception greatly reduces cognitive load. When a developer encounters an error in their session tests, they will instantly understand that the issue originates from passing an invalid type as an attribute name (rather than having to guess why a core PHP `InvalidArgumentException` was thrown). This adheres to the DX principle of "Clear Errors".
🛠️ Tooling: Improves type safety and ensures developers don't have to trace the origin of generic exceptions.

---
*PR created automatically by Jules for task [10958249995978783093](https://jules.google.com/task/10958249995978783093) started by @TavoNiievez*