### PR TITLE
🎨 Palette (DX): Replace generic InvalidArgumentException with InvalidSessionAttributeException

### DIFF
--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException {}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Exception\InvalidSessionAttributeException;
 use InvalidArgumentException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
@@ -174,7 +175,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: The DX enhancement added.
Extracts the generic `InvalidArgumentException` thrown by `SessionAssertionsTrait::seeSessionHasValues` into a highly specific `InvalidSessionAttributeException` class.

🎯 Why: How it reduces cognitive load or prevents bugs.
Reduces cognitive load when debugging failing tests. Custom Exceptions make the code self-documenting and tell the developer exactly what went wrong at the class level without needing to read the specific error string.

🛠️ Tooling: If it improves PHPStan/IDE support.
Improves discoverability for IDE tools and allows consumers of the module to catch specific errors rather than broad validation exceptions. Tests pass locally and PHPStan level 8 detects no errors.

---
*PR created automatically by Jules for task [9347512449647382389](https://jules.google.com/task/9347512449647382389) started by @TavoNiievez*