### PR TITLE
⚡ Bolt: Optimize array deduplication in CacheTrait

### DIFF
--- a/src/Codeception/Module/Symfony/CacheTrait.php
+++ b/src/Codeception/Module/Symfony/CacheTrait.php
@@ -8,8 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
 use function array_key_exists;
-use function array_unique;
-use function array_values;
+use function array_keys;
 use function is_string;
 
 trait CacheTrait
@@ -48,12 +47,12 @@ trait CacheTrait
 
             $hostRegex = $route->compile()->getHostRegex();
             if ($hostRegex !== null && $hostRegex !== '') {
-                $domains[] = $hostRegex;
+                $domains[$hostRegex] = true;
             }
         }
 
         /** @var list<non-empty-string> $domains */
-        $domains = array_values(array_unique($domains));
+        $domains = array_keys($domains);
         return $this->state['internalDomains'] = $domains;
     }
 


### PR DESCRIPTION
💡 What: Optimized the deduplication process in `CacheTrait::getInternalDomains` by using an associative array for O(1) lookups instead of `array_values(array_unique())`.

🎯 Why: The original `array_unique` is `O(N log N)` because it internally relies on sorting or hashing to identify unique values. When a large collection of routes is processed, this causes unnecessary performance overhead. Switching to array keys makes the collection process `O(1)` per item and `O(N)` overall, avoiding the sorting completely.

📊 Impact: Converts an `O(N log N)` deduplication step into `O(N)`. Memory allocations are marginally reduced because `array_unique()` internally duplicates array contents while checking.

🔬 Measurement: Run `vendor/bin/phpunit tests/` and verify that no logic has broken while the operation runs faster over large `RouteCollection` iterations.

---
*PR created automatically by Jules for task [18138835084064469108](https://jules.google.com/task/18138835084064469108) started by @TavoNiievez*