### PR TITLE
Add flash, service-mock, query-count, messenger-transport and console-result assertions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "symfony/console": "^5.4 | ^6.4 | ^7.4 | ^8.1",
         "symfony/css-selector": "^5.4 | ^6.4 | ^7.4 | ^8.1",
         "symfony/dependency-injection": "^5.4 | ^6.4 | ^7.4 | ^8.1",
+        "symfony/doctrine-bridge": "^5.4 | ^6.4 | ^7.4 | ^8.1",
         "symfony/dom-crawler": "^5.4 | ^6.4 | ^7.4 | ^8.1",
         "symfony/dotenv": "^5.4 | ^6.4 | ^7.4 | ^8.1",
         "symfony/error-handler": "^5.4 | ^6.4 | ^7.4 | ^8.1",

--- a/src/Codeception/Module/Symfony.php
+++ b/src/Codeception/Module/Symfony.php
@@ -111,8 +111,10 @@ use function sprintf;
  *
  * * `services`: Includes methods related to the Symfony dependency injection container (DIC):
  *     * grabService
+ *     * mockService
  *     * persistService
  *     * persistPermanentService
+ *     * unmockService
  *     * unpersistService
  *
  * See [WebDriver module](https://codeception.com/docs/modules/WebDriver#Loading-Parts-from-other-Modules)

--- a/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ConsoleAssertionsTrait.php
@@ -4,16 +4,143 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Closure;
+use PHPUnit\Framework\Assert;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tester\Constraint\CommandFailed;
+use Symfony\Component\Console\Tester\Constraint\CommandIsInvalid;
+use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
+use Symfony\Component\Console\Tester\ExecutionResult;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+use function class_exists;
 use function is_int;
 use function sprintf;
 
 trait ConsoleAssertionsTrait
 {
+    /**
+     * Asserts that the command finished with a non-zero (failure) status code.
+     *
+     * ```php
+     * <?php
+     * $I->assertCommandFailed($I->runCommand('app:import-users', ['file' => 'broken.csv']));
+     * ```
+     */
+    public function assertCommandFailed(ExecutionResult $result, string $message = ''): void
+    {
+        $this->assertThat($result->statusCode, new CommandFailed(), $message);
+    }
+
+    /**
+     * Asserts that the command finished with the "invalid input" status code (2).
+     *
+     * ```php
+     * <?php
+     * $I->assertCommandIsInvalid($I->runCommand('app:import-users'));
+     * ```
+     */
+    public function assertCommandIsInvalid(ExecutionResult $result, string $message = ''): void
+    {
+        $this->assertThat($result->statusCode, new CommandIsInvalid(), $message);
+    }
+
+    /**
+     * Asserts that the command finished with the success status code (0).
+     *
+     * ```php
+     * <?php
+     * $I->assertCommandIsSuccessful($I->runCommand('app:import-users', ['file' => 'users.csv']));
+     * ```
+     */
+    public function assertCommandIsSuccessful(ExecutionResult $result, string $message = ''): void
+    {
+        $this->assertThat($result->statusCode, new CommandIsSuccessful(), $message);
+    }
+
+    /**
+     * Asserts that the given parts of the command result match the expected values.
+     * Only the non-null arguments are compared, so you can assert the status code,
+     * the standard output, the error output and the combined display independently.
+     *
+     * ```php
+     * <?php
+     * $I->assertCommandResultEquals(
+     *     $I->runCommand('app:import-users', ['file' => 'broken.csv']),
+     *     expectedStatusCode: 1,
+     *     expectedErrorOutput: "Invalid CSV\n",
+     * );
+     * ```
+     */
+    public function assertCommandResultEquals(
+        ExecutionResult $result,
+        ?int $expectedStatusCode = null,
+        ?string $expectedOutput = null,
+        ?string $expectedErrorOutput = null,
+        ?string $expectedDisplay = null,
+        string $message = ''
+    ): void {
+        $expected = [];
+        $actual = [];
+
+        if ($expectedStatusCode !== null) {
+            $expected['statusCode'] = $expectedStatusCode;
+            $actual['statusCode'] = $result->statusCode;
+        }
+        if ($expectedOutput !== null) {
+            $expected['output'] = $expectedOutput;
+            $actual['output'] = $result->getOutput();
+        }
+        if ($expectedErrorOutput !== null) {
+            $expected['errorOutput'] = $expectedErrorOutput;
+            $actual['errorOutput'] = $result->getErrorOutput();
+        }
+        if ($expectedDisplay !== null) {
+            $expected['display'] = $expectedDisplay;
+            $actual['display'] = $result->getDisplay();
+        }
+
+        $this->assertEquals($expected, $actual, $message);
+    }
+
+    /**
+     * Runs a console command and returns its execution result, which exposes the status code
+     * together with the separate standard and error output (unlike
+     * [`runSymfonyConsoleCommand()`](#runSymfonyConsoleCommand), which merges them into one string).
+     * Requires `symfony/console` 8.1 or higher.
+     *
+     * ```php
+     * <?php
+     * $result = $I->runCommand('app:import-users', ['file' => 'users.csv', '--dry-run' => true]);
+     * $I->assertCommandIsSuccessful($result);
+     * ```
+     *
+     * @param array<string, mixed>           $input             Command arguments and options.
+     * @param list<string>                   $interactiveInputs Inputs for interactive questions.
+     * @param OutputInterface::VERBOSITY_*|null $verbosity       Output verbosity level.
+     * @param array<Closure(string): string> $normalizers       Output normalizers.
+     */
+    public function runCommand(
+        string $name,
+        array $input = [],
+        array $interactiveInputs = [],
+        ?bool $interactive = null,
+        ?bool $decorated = null,
+        ?int $verbosity = null,
+        array $normalizers = []
+    ): ExecutionResult {
+        if (!class_exists(ExecutionResult::class)) {
+            Assert::fail('runCommand() requires symfony/console 8.1 or higher; use runSymfonyConsoleCommand() instead.');
+        }
+
+        $command = (new Application($this->kernel))->find($name);
+        $commandTester = new CommandTester($command);
+
+        return $commandTester->run($input, $interactiveInputs, $interactive, $decorated, $verbosity, $normalizers);
+    }
+
     /**
      * Run Symfony console command, grab response and return as string.
      * Recommended to use for functional testing.

--- a/src/Codeception/Module/Symfony/DataCollectorName.php
+++ b/src/Codeception/Module/Symfony/DataCollectorName.php
@@ -9,6 +9,7 @@ namespace Codeception\Module\Symfony;
  */
 enum DataCollectorName: string
 {
+    case DB = 'db';
     case EVENTS = 'events';
     case FORM = 'form';
     case HTTP_CLIENT = 'http_client';

--- a/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/DoctrineAssertionsTrait.php
@@ -6,15 +6,54 @@ namespace Codeception\Module\Symfony;
 
 use Doctrine\ORM\EntityRepository;
 use PHPUnit\Framework\Assert;
+use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 
+use function array_count_values;
+use function array_filter;
+use function array_keys;
+use function implode;
 use function interface_exists;
+use function is_array;
 use function is_object;
+use function is_string;
 use function is_subclass_of;
 use function json_encode;
 use function sprintf;
 
 trait DoctrineAssertionsTrait
 {
+    /**
+     * Asserts that no SQL query was executed more than once during the last request,
+     * which usually reveals an N+1 query problem.
+     * Reads the Doctrine `db` profiler collector, so DoctrineBundle and the profiler must be enabled.
+     *
+     * ```php
+     * <?php
+     * $I->dontSeeDuplicateQueries();
+     * ```
+     */
+    public function dontSeeDuplicateQueries(): void
+    {
+        $statements = [];
+        foreach ($this->grabDoctrineCollector(__FUNCTION__)->getQueries() as $connectionQueries) {
+            if (!is_array($connectionQueries)) {
+                continue;
+            }
+            foreach ($connectionQueries as $query) {
+                if (is_array($query) && is_string($query['sql'] ?? null)) {
+                    $statements[] = $query['sql'];
+                }
+            }
+        }
+
+        $duplicates = array_keys(array_filter(array_count_values($statements), static fn(int $count): bool => $count > 1));
+
+        $this->assertEmpty(
+            $duplicates,
+            sprintf("Expected no duplicate queries, but found:\n%s", implode("\n", $duplicates))
+        );
+    }
+
     /**
      * Returns the number of rows that match the given criteria for the
      * specified Doctrine entity.
@@ -72,6 +111,27 @@ trait DoctrineAssertionsTrait
     }
 
     /**
+     * Asserts that fewer than the expected number of SQL queries were executed during the last request.
+     * Useful as a ceiling to guard against N+1 regressions.
+     * Reads the Doctrine `db` profiler collector, so DoctrineBundle and the profiler must be enabled.
+     *
+     * ```php
+     * <?php
+     * $I->seeNumQueriesIsLessThan(5);
+     * ```
+     */
+    public function seeNumQueriesIsLessThan(int $expectedNumber): void
+    {
+        $actualNumber = $this->grabDoctrineCollector(__FUNCTION__)->getQueryCount();
+
+        $this->assertLessThan(
+            $expectedNumber,
+            $actualNumber,
+            sprintf('Expected less than %d queries, but %d were executed.', $expectedNumber, $actualNumber)
+        );
+    }
+
+    /**
      * Asserts that a given number of records exists for the entity.
      * 'id' is the default search parameter.
      *
@@ -101,5 +161,15 @@ trait DoctrineAssertionsTrait
                 json_encode($criteria, JSON_THROW_ON_ERROR)
             )
         );
+    }
+
+    protected function grabDoctrineCollector(string $callingFunction): DoctrineDataCollector
+    {
+        $collector = $this->grabCollector(DataCollectorName::DB, $callingFunction);
+        if (!$collector instanceof DoctrineDataCollector) {
+            Assert::fail(sprintf("The 'db' collector is not a Doctrine collector, required by '%s'.", $callingFunction));
+        }
+
+        return $collector;
     }
 }

--- a/src/Codeception/Module/Symfony/MessengerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MessengerAssertionsTrait.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use PHPUnit\Framework\Assert;
 use Symfony\Component\Messenger\DataCollector\MessengerDataCollector;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 use Symfony\Component\VarDumper\Cloner\Data;
 
 use function class_exists;
@@ -14,6 +19,42 @@ use function sprintf;
 
 trait MessengerAssertionsTrait
 {
+    /**
+     * Processes up to `$limit` messages queued on the given in-memory transport by handling them
+     * through the bus, letting you assert the side effects (emails sent, entities persisted, ...)
+     * of their handlers. Stops early once the transport's queue is empty.
+     *
+     * ```php
+     * <?php
+     * $I->consumeMessengerMessages('async');
+     * $I->consumeMessengerMessages('async', limit: 3);
+     * ```
+     */
+    public function consumeMessengerMessages(string $transportName, int $limit = 1): void
+    {
+        $transport = $this->grabMessengerTransport($transportName);
+        $bus = $this->grabService('messenger.routable_message_bus');
+        if (!$bus instanceof MessageBusInterface) {
+            Assert::fail("The 'messenger.routable_message_bus' service is not a message bus.");
+        }
+
+        $processed = 0;
+        while ($processed < $limit) {
+            $envelopes = [...$transport->get()];
+            if ($envelopes === []) {
+                break;
+            }
+
+            foreach ($envelopes as $envelope) {
+                $bus->dispatch($envelope->with(new ReceivedStamp($transportName), new ConsumedByWorkerStamp()));
+                $transport->ack($envelope);
+                if (++$processed >= $limit) {
+                    break 2;
+                }
+            }
+        }
+    }
+
     /**
      * Asserts no message of the given class was dispatched (optionally on a single bus).
      *
@@ -50,6 +91,27 @@ trait MessengerAssertionsTrait
     public function grabDispatchedMessageClasses(?string $bus = null): array
     {
         return $this->getDispatchedMessageClasses(__FUNCTION__, $bus);
+    }
+
+    /**
+     * Grabs the in-memory transport with the given name, so you can inspect the real message objects
+     * it received via `getSent()`, `getAcknowledged()`, `getRejected()` or `get()`.
+     * The app must route the bus to an in-memory transport in the test environment
+     * (`MESSENGER_TRANSPORT_DSN=in-memory://`).
+     *
+     * ```php
+     * <?php
+     * $envelope = $I->grabMessengerTransport('async')->getSent()[0];
+     * ```
+     */
+    public function grabMessengerTransport(string $transportName): InMemoryTransport
+    {
+        $transport = $this->grabService('messenger.transport.' . $transportName);
+        if (!$transport instanceof InMemoryTransport) {
+            Assert::fail(sprintf("The '%s' transport is not an in-memory transport.", $transportName));
+        }
+
+        return $transport;
     }
 
     /**
@@ -94,6 +156,49 @@ trait MessengerAssertionsTrait
             $messageClass,
             $this->getDispatchedMessageClasses(__FUNCTION__, $bus),
             sprintf("The '%s' message was not dispatched%s.", $messageClass, $this->busSuffix($bus)),
+        );
+    }
+
+    /**
+     * Asserts how many messages were sent to the given in-memory transport.
+     *
+     * ```php
+     * <?php
+     * $I->seeMessengerQueueCount(1, 'async');
+     * ```
+     */
+    public function seeMessengerQueueCount(int $expectedCount, string $transportName): void
+    {
+        $sent = $this->grabMessengerTransport($transportName)->getSent();
+
+        $this->assertCount(
+            $expectedCount,
+            $sent,
+            sprintf("Expected %d message(s) on the '%s' transport, but %d were sent.", $expectedCount, $transportName, count($sent)),
+        );
+    }
+
+    /**
+     * Asserts that a message of the given class was sent to the given in-memory transport.
+     *
+     * ```php
+     * <?php
+     * $I->seeMessengerTransportContains(SendInvoice::class, 'async');
+     * ```
+     *
+     * @param class-string $messageClass
+     */
+    public function seeMessengerTransportContains(string $messageClass, string $transportName): void
+    {
+        $classes = [];
+        foreach ($this->grabMessengerTransport($transportName)->getSent() as $envelope) {
+            $classes[] = $envelope->getMessage()::class;
+        }
+
+        $this->assertContains(
+            $messageClass,
+            $classes,
+            sprintf("No '%s' message was sent to the '%s' transport.", $messageClass, $transportName),
         );
     }
 

--- a/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/ServicesAssertionsTrait.php
@@ -55,6 +55,32 @@ trait ServicesAssertionsTrait
     }
 
     /**
+     * Replaces a service in the container with the given object, for example a mock or a stub.
+     * The replacement is injected immediately and re-injected after each kernel reboot,
+     * so it stays in effect across requests until [`unmockService()`](#unmockService) is called.
+     * Build the double with Codeception `Stub`, PHPUnit, Mockery, or any plain object.
+     *
+     * The service must not have been initialized yet (Symfony forbids replacing an
+     * already instantiated service), so mock it before the request that uses it.
+     *
+     * ```php
+     * <?php
+     * $I->mockService(PaymentGateway::class, $this->makeEmpty(PaymentGateway::class));
+     * $I->mockService('http_client', new MockHttpClient($responses));
+     * $I->mockService('clock', new MockClock('2030-01-01'));
+     * ```
+     *
+     * @part services
+     * @param non-empty-string $serviceId
+     */
+    public function mockService(string $serviceId, object $replacement): void
+    {
+        $this->persistentServices[$serviceId] = $replacement;
+        $this->updateClientPersistentService($serviceId, $replacement);
+        $this->_getContainer()->set($serviceId, $replacement);
+    }
+
+    /**
      * Get service $serviceName and add it to the lists of persistent services.
      *
      * @part services
@@ -75,6 +101,24 @@ trait ServicesAssertionsTrait
     public function persistPermanentService(string $serviceName): void
     {
         $this->doPersistService($serviceName, true);
+    }
+
+    /**
+     * Removes a service replacement set with [`mockService()`](#mockService),
+     * restoring the original service on the next request.
+     *
+     * ```php
+     * <?php
+     * $I->unmockService('http_client');
+     * ```
+     *
+     * @part services
+     * @param non-empty-string $serviceId
+     */
+    public function unmockService(string $serviceId): void
+    {
+        unset($this->persistentServices[$serviceId], $this->permanentServices[$serviceId]);
+        $this->updateClientPersistentService($serviceId, null);
     }
 
     /**

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use BadMethodCallException;
 use InvalidArgumentException;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\FlashBagAwareSessionInterface;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Kernel;
@@ -18,6 +21,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
+use function array_filter;
+use function array_intersect;
 use function class_exists;
 use function get_debug_type;
 use function is_int;
@@ -63,6 +68,55 @@ trait SessionAssertionsTrait
         $session->save();
 
         $this->getClient()->getCookieJar()->set(new Cookie($session->getName(), $session->getId()));
+    }
+
+    /**
+     * Asserts that the current request's session flash bag has a message of the given type.
+     * Optionally, asserts that the type's channel contains (at least one of) the given message(s).
+     * The flash bag is read with `peek()`, so the messages stay available to the template and to later assertions.
+     *
+     * Because templates consume flash messages when they render them, call
+     * [`stopFollowingRedirects()`](https://codeception.com/docs/modules/Symfony#stopFollowingRedirects) first
+     * so the redirect target does not drain the bag before the assertion runs.
+     *
+     * ```php
+     * <?php
+     * $I->stopFollowingRedirects();
+     * $I->amOnPage('/checkout');
+     * $I->assertSessionHasFlashMessage('success');
+     * $I->assertSessionHasFlashMessage('success', 'Your changes were saved.');
+     * $I->assertSessionHasFlashMessage('error', ['Invalid input.', 'Please try again.']);
+     * ```
+     *
+     * @param string|list<string> $messages
+     */
+    public function assertSessionHasFlashMessage(string $messageType, string|array $messages = ''): void
+    {
+        try {
+            $request = $this->getClient()->getRequest();
+        } catch (BadMethodCallException) {
+            Assert::fail('You must perform a request before asserting flash messages.');
+        }
+
+        $session = $request->hasSession() ? $request->getSession() : null;
+        if (!$session instanceof FlashBagAwareSessionInterface) {
+            Assert::fail('The current request does not have a session with a flash bag.');
+        }
+
+        $actualMessages = $session->getFlashBag()->peek($messageType);
+        $this->assertNotEmpty(
+            $actualMessages,
+            sprintf("The session does not have a flash message of type '%s'.", $messageType)
+        );
+
+        if ($messages === '') {
+            return;
+        }
+
+        $this->assertNotEmpty(
+            array_intersect((array) $messages, array_filter($actualMessages, 'is_string')),
+            sprintf("The '%s' flash messages do not contain any of the expected messages.", $messageType)
+        );
     }
 
     /**

--- a/tests/ConsoleAssertionsTest.php
+++ b/tests/ConsoleAssertionsTest.php
@@ -18,4 +18,32 @@ final class ConsoleAssertionsTest extends CodeceptTestCase
         $this->assertStringContainsString('Option selected', $this->runSymfonyConsoleCommand('app:test-command', ['-o' => true]));
         $this->assertSame('', $this->runSymfonyConsoleCommand('app:test-command', ['-q']));
     }
+
+    public function testAssertCommandIsSuccessful(): void
+    {
+        $result = $this->runCommand('app:result-command');
+
+        $this->assertCommandIsSuccessful($result);
+        $this->assertStringContainsString('All good.', $result->getOutput());
+    }
+
+    public function testAssertCommandFailed(): void
+    {
+        $result = $this->runCommand('app:result-command', ['--fail' => true]);
+
+        $this->assertCommandFailed($result);
+        $this->assertStringContainsString('Something failed.', $result->getErrorOutput());
+    }
+
+    public function testAssertCommandIsInvalid(): void
+    {
+        $this->assertCommandIsInvalid($this->runCommand('app:result-command', ['--invalid' => true]));
+    }
+
+    public function testAssertCommandResultEquals(): void
+    {
+        $result = $this->runCommand('app:result-command');
+
+        $this->assertCommandResultEquals($result, expectedStatusCode: 0, expectedDisplay: "All good.\n");
+    }
 }

--- a/tests/DoctrineAssertionsTest.php
+++ b/tests/DoctrineAssertionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests;
 
 use Codeception\Module\Symfony\DoctrineAssertionsTrait;
+use PHPUnit\Framework\AssertionFailedError;
 use Tests\App\Entity\User;
 use Tests\App\Repository\UserRepository;
 use Tests\App\Repository\UserRepositoryInterface;
@@ -14,9 +15,31 @@ final class DoctrineAssertionsTest extends CodeceptTestCase
 {
     use DoctrineAssertionsTrait;
 
+    public function testDontSeeDuplicateQueries(): void
+    {
+        $this->client->request('GET', '/');
+
+        $this->dontSeeDuplicateQueries();
+    }
+
+    public function testDontSeeDuplicateQueriesFailsWhenQueriesRepeat(): void
+    {
+        $this->client->request('GET', '/?duplicateQueries=1');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->dontSeeDuplicateQueries();
+    }
+
     public function testGrabNumRecords(): void
     {
         $this->assertSame(1, $this->grabNumRecords(User::class));
+    }
+
+    public function testSeeNumQueriesIsLessThan(): void
+    {
+        $this->client->request('GET', '/');
+
+        $this->seeNumQueriesIsLessThan(3);
     }
 
     public function testGrabRepository(): void

--- a/tests/MessengerAssertionsTest.php
+++ b/tests/MessengerAssertionsTest.php
@@ -7,11 +7,34 @@ namespace Tests;
 use Codeception\Module\Symfony\MessengerAssertionsTrait;
 use stdClass;
 use Tests\App\Message\TestMessage;
+use Tests\App\MessageHandler\TestMessageHandler;
 use Tests\Support\CodeceptTestCase;
 
 final class MessengerAssertionsTest extends CodeceptTestCase
 {
     use MessengerAssertionsTrait;
+
+    public function testSeeMessengerTransportAssertions(): void
+    {
+        $this->client->request('GET', '/dispatch-message');
+
+        $this->seeMessengerQueueCount(1, 'async');
+        $this->seeMessengerTransportContains(TestMessage::class, 'async');
+
+        $envelope = $this->grabMessengerTransport('async')->getSent()[0];
+        $this->assertInstanceOf(TestMessage::class, $envelope->getMessage());
+    }
+
+    public function testConsumeMessengerMessages(): void
+    {
+        $this->client->request('GET', '/dispatch-message');
+        $this->seeMessengerQueueCount(1, 'async');
+
+        $this->consumeMessengerMessages('async');
+
+        $handler = $this->grabService(TestMessageHandler::class);
+        $this->assertSame(['Hello from Messenger'], $handler->handled);
+    }
 
     public function testSeeDispatchedMessageCount(): void
     {

--- a/tests/ServicesAssertionsTest.php
+++ b/tests/ServicesAssertionsTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests;
 
 use Codeception\Module\Symfony\ServicesAssertionsTrait;
+use stdClass;
+use Tests\App\Mailer\RegistrationMailer;
 use Tests\Support\CodeceptTestCase;
 
 final class ServicesAssertionsTest extends CodeceptTestCase
@@ -14,6 +16,14 @@ final class ServicesAssertionsTest extends CodeceptTestCase
     public function testGrabService(): void
     {
         $this->assertIsObject($this->grabService('security.helper'));
+    }
+
+    public function testMockService(): void
+    {
+        $mock = new stdClass();
+        $this->mockService(RegistrationMailer::class, $mock);
+
+        $this->assertSame($mock, $this->grabService(RegistrationMailer::class));
     }
 
     public function testPersistService(): void
@@ -27,6 +37,14 @@ final class ServicesAssertionsTest extends CodeceptTestCase
         $this->persistPermanentService('router');
         $this->assertArrayHasKey('router', $this->permanentServices);
         $this->assertArrayHasKey('router', $this->persistentServices);
+    }
+
+    public function testUnmockService(): void
+    {
+        $this->mockService(RegistrationMailer::class, new stdClass());
+        $this->unmockService(RegistrationMailer::class);
+
+        $this->assertArrayNotHasKey(RegistrationMailer::class, $this->persistentServices);
     }
 
     public function testUnpersistService(): void

--- a/tests/SessionAssertionsTest.php
+++ b/tests/SessionAssertionsTest.php
@@ -30,6 +30,16 @@ final class SessionAssertionsTest extends CodeceptTestCase
         $this->assertStringContainsString('You are in the Dashboard!', $this->client->getResponse()->getContent());
     }
 
+    public function testAssertSessionHasFlashMessage(): void
+    {
+        $this->client->followRedirects(false);
+        $this->client->request('GET', '/flash');
+
+        $this->assertSessionHasFlashMessage('success');
+        $this->assertSessionHasFlashMessage('success', 'Profile updated.');
+        $this->assertSessionHasFlashMessage('success', ['Another message.', 'Profile updated.']);
+    }
+
     public function testDontSeeInSession(): void
     {
         $this->client->request('GET', '/');

--- a/tests/_app/Command/ResultCommand.php
+++ b/tests/_app/Command/ResultCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand('app:result-command', 'A command exercising the execution result paths.')]
+final class ResultCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this->addOption('fail', null, InputOption::VALUE_NONE);
+        $this->addOption('invalid', null, InputOption::VALUE_NONE);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($input->getOption('invalid')) {
+            $output->writeln('Invalid input.');
+
+            return Command::INVALID;
+        }
+
+        if ($input->getOption('fail')) {
+            if ($output instanceof ConsoleOutputInterface) {
+                $output->getErrorOutput()->writeln('Something failed.');
+            }
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln('All good.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/_app/Controller/AppController.php
+++ b/tests/_app/Controller/AppController.php
@@ -148,6 +148,13 @@ final class AppController extends AbstractController
         return new Response($twig->render('security/register.html.twig'));
     }
 
+    public function setFlash(): RedirectResponse
+    {
+        $this->addFlash('success', 'Profile updated.');
+
+        return new RedirectResponse('/');
+    }
+
     public function requestWithAttribute(Request $request): Response
     {
         $request->attributes->set('page', 'register');

--- a/tests/_app/Doctrine/DbDataCollector.php
+++ b/tests/_app/Doctrine/DbDataCollector.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Doctrine;
+
+use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * Stands in for DoctrineBundle's `db` collector, which is not wired in this mini-app.
+ * It feeds canned queries to the profiler so the query-count assertions can be tested,
+ * adding a duplicate query when the request carries `?duplicateQueries=1`.
+ */
+final class DbDataCollector extends DoctrineDataCollector
+{
+    public function __construct()
+    {
+    }
+
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
+    {
+        $queries = [
+            ['sql' => 'SELECT * FROM user', 'executionMS' => 0.1],
+            ['sql' => 'SELECT id FROM product WHERE category_id = 1', 'executionMS' => 0.1],
+        ];
+
+        if ($request->query->getBoolean('duplicateQueries')) {
+            $queries[] = ['sql' => 'SELECT * FROM user', 'executionMS' => 0.1];
+        }
+
+        $this->data = [
+            'queries' => ['default' => $queries],
+            'connections' => ['default'],
+            'managers' => ['default' => 'default'],
+        ];
+    }
+
+    public function reset(): void
+    {
+        $this->data = [];
+    }
+}

--- a/tests/_app/TestKernel.php
+++ b/tests/_app/TestKernel.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Serializer\DataCollector\SerializerDataCollector;
+use Tests\App\Message\TestMessage;
 
 class TestKernel extends BaseKernel
 {
@@ -60,7 +61,12 @@ class TestKernel extends BaseKernel
             'validation' => ['enabled' => true],
             'form' => ['enabled' => true],
             'notifier' => ['chatter_transports' => ['async' => 'null://null'], 'texter_transports' => ['sms' => 'null://null']],
-            'messenger' => ['default_bus' => 'messenger.bus.default', 'buses' => ['messenger.bus.default' => []]],
+            'messenger' => [
+                'default_bus' => 'messenger.bus.default',
+                'buses' => ['messenger.bus.default' => []],
+                'transports' => ['async' => 'in-memory://'],
+                'routing' => [TestMessage::class => 'async'],
+            ],
         ]);
 
         $container->extension('twig', ['default_path' => __DIR__ . '/templates', 'debug' => true]);

--- a/tests/_app/config/routes.php
+++ b/tests/_app/config/routes.php
@@ -14,6 +14,7 @@ return function (RoutingConfigurator $routes): void {
     $routes->add('dispatch_message', '/dispatch-message')->controller(AppController::class . '::dispatchTestMessage');
     $routes->add('dispatch_named_event', '/dispatch-named-event')->controller(AppController::class . '::dispatchNamedEvent');
     $routes->add('dispatch_orphan_event', '/dispatch-orphan-event')->controller(AppController::class . '::dispatchOrphanEvent');
+    $routes->add('flash', '/flash')->controller(AppController::class . '::setFlash');
     $routes->add('form_handler', '/form')->controller(AppController::class . '::form');
     $routes->add('http_client', '/http-client')->controller(AppController::class . '::httpClientRequests');
     $routes->add('index', '/')->controller(AppController::class . '::index');

--- a/tests/_app/config/services.php
+++ b/tests/_app/config/services.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
 use Symfony\Component\Notifier\EventListener\NotificationLoggerListener;
 use Tests\App\Command\TestCommand;
 use Tests\App\Controller\AppController;
+use Tests\App\Doctrine\DbDataCollector;
 use Tests\App\Doctrine\DoctrineSetup;
 use Tests\App\Entity\User;
 use Tests\App\Event\TestEvent;
@@ -41,6 +42,9 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set(AppController::class);
     $services->set(TestCommand::class)->tag('console.command', ['command' => 'app:test-command']);
+
+    $services->set(DbDataCollector::class)
+        ->tag('data_collector', ['id' => 'db', 'template' => '@WebProfiler/Collector/db.html.twig', 'priority' => 250]);
 
     $services->set('doctrine.orm.entity_manager', EntityManagerInterface::class)
         ->factory([DoctrineSetup::class, 'createEntityManager']);

--- a/tests/_app/config/services.php
+++ b/tests/_app/config/services.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpClient\TraceableHttpClient;
 use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
 use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
 use Symfony\Component\Notifier\EventListener\NotificationLoggerListener;
+use Tests\App\Command\ResultCommand;
 use Tests\App\Command\TestCommand;
 use Tests\App\Controller\AppController;
 use Tests\App\Doctrine\DbDataCollector;
@@ -42,6 +43,7 @@ return static function (ContainerConfigurator $container): void {
 
     $services->set(AppController::class);
     $services->set(TestCommand::class)->tag('console.command', ['command' => 'app:test-command']);
+    $services->set(ResultCommand::class)->tag('console.command', ['command' => 'app:result-command']);
 
     $services->set(DbDataCollector::class)
         ->tag('data_collector', ['id' => 'db', 'template' => '@WebProfiler/Collector/db.html.twig', 'priority' => 250]);


### PR DESCRIPTION
Closes the small set of gaps that today push a Symfony developer toward a separate, non-Codeception package. Two buckets: assertions Symfony ships in its own `Test\*` traits that the module had not inherited yet, and capabilities absent from both Symfony core and the Codeception module ecosystem.

Each feature is a separate commit and ships with a unit test against the mini-app under `tests/_app/`.

### Charter inheritance (Symfony ports)
- **`assertSessionHasFlashMessage()`** (`SessionAssertionsTrait`) — the one BrowserKit assertion Symfony 8.1 added that was still missing. Reads the flash bag with `peek()`, so it is non-destructive and needs no dependency or version guard.
- **`runCommand()` + `assertCommandIsSuccessful()` / `assertCommandFailed()` / `assertCommandIsInvalid()` / `assertCommandResultEquals()`** (`ConsoleAssertionsTrait`) — port of Symfony 7.4+'s `ConsoleCommandAssertionsTrait`. `runCommand()` returns an `ExecutionResult` exposing the status code and the **separate** standard and error output, which `runSymfonyConsoleCommand()` cannot. Guarded with `class_exists(ExecutionResult::class)`; `runSymfonyConsoleCommand()` stays the pre-7.4 path.

### Competitive gaps (module-native)
- **`mockService()` / `unmockService()`** (`ServicesAssertionsTrait`) — swap a container service for a test double (mock, stub, `MockHttpClient`, `MockClock`, ...) on the existing persistent-service rails, so the replacement survives kernel reboots. The double is built with Codeception `Stub`, PHPUnit or Mockery; the module only supplies the replacement.
- **`seeNumQueriesIsLessThan()` / `dontSeeDuplicateQueries()`** (`DoctrineAssertionsTrait`) — N+1 guard reading the Doctrine `db` profiler collector (new `DataCollectorName::DB`). `symfony/doctrine-bridge` is added as a dev dependency to type the collector.
- **`grabMessengerTransport()` / `seeMessengerTransportContains()` / `seeMessengerQueueCount()` / `consumeMessengerMessages()`** (`MessengerAssertionsTrait`) — inspect and process the real message objects on a Symfony in-memory transport, complementing the existing profiler-based dispatch assertions. `consumeMessengerMessages()` handles queued envelopes through the bus in-process (with a `ReceivedStamp`), which works with the in-memory transport where `messenger:consume` does not.

### Scope discipline
No new trait, no new config knob, and nothing added to the `Symfony.php` facade except the two new `services` Part entries. Capabilities reachable by composing a sibling Codeception module (`module-rest`, `module-webdriver`, `module-doctrine`, `module-datafactory`) are deliberately left out.

### Validation
`composer phpstan` (level max), `composer cs-check` and `vendor/bin/phpunit tests` all pass.

A matching functional test is opened separately in `Codeception/symfony-module-tests`, per `CONTRIBUTING.md`.