### PR TITLE
🎨 Palette (DX): Use typed exception for Session Assertions

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Typed exception for Session Assertions
+**Learning:** Generic `InvalidArgumentException` used for type checking reduces clarity and prevents specific exception handling.
+**Action:** Use a specific custom exception (`InvalidSessionAttributeException`) and improve types in session bindings.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Replaced the generic `InvalidArgumentException` with a specific custom exception (`InvalidSessionAttributeException`) in `SessionAssertionsTrait`.
🎯 Why: Throwing a specific exception rather than a generic one allows developers testing their session bindings to explicitly catch and handle session-related assertion errors without inadvertently catching other `InvalidArgumentException` issues that may occur, reducing cognitive load and mystery bugs.
🛠️ Tooling: Improved exact error discoverability while maintaining full backward compatibility by keeping the new exception a child of `InvalidArgumentException`.

---
*PR created automatically by Jules for task [8827121814081235770](https://jules.google.com/task/8827121814081235770) started by @TavoNiievez*