### PR TITLE
⚡ Bolt: Optimize `array_unique` overhead in CacheTrait

### DIFF
--- a/src/Codeception/Module/Symfony/CacheTrait.php
+++ b/src/Codeception/Module/Symfony/CacheTrait.php
@@ -8,8 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
 use function array_key_exists;
-use function array_unique;
-use function array_values;
+use function array_keys;
 use function is_string;
 
 trait CacheTrait
@@ -48,12 +47,12 @@ trait CacheTrait
 
             $hostRegex = $route->compile()->getHostRegex();
             if ($hostRegex !== null && $hostRegex !== '') {
-                $domains[] = $hostRegex;
+                $domains[$hostRegex] = true;
             }
         }
 
         /** @var list<non-empty-string> $domains */
-        $domains = array_values(array_unique($domains));
+        $domains = array_keys($domains);
         return $this->state['internalDomains'] = $domains;
     }
 


### PR DESCRIPTION
💡 What: Replaced `array_values(array_unique($domains))` with associative array keys (`$domains[$hostRegex] = true`) followed by `array_keys($domains)` in `CacheTrait::getInternalDomains()`.

🎯 Why: To improve performance when collecting and deduplicating route domains. The previous approach used `array_unique`, which involves sorting the array first, making it O(N log N). Using associative array keys implicitly handles uniqueness in O(N) time and avoids the sorting overhead.

📊 Impact: Reduces time complexity from O(N log N) to O(N) and lowers memory consumption, particularly beneficial when a Symfony application has a large number of routes with various host regexes.

🔬 Measurement: Run `vendor/bin/phpunit tests/` and verify that all 161 tests continue to pass seamlessly. Review static analysis via `vendor/bin/phpstan analyse src --level=max` to ensure type signatures remain valid.

---
*PR created automatically by Jules for task [3242691188770565859](https://jules.google.com/task/3242691188770565859) started by @TavoNiievez*