### PR TITLE
🎨 Palette (DX): Add InvalidSessionAttributeException

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-06-29 - [Custom Exception for Session Attribute Assertion]
+**Learning:** `InvalidArgumentException` was being thrown with a specific error message directly inside `SessionAssertionsTrait::seeSessionHasValues`. A custom exception `InvalidSessionAttributeException` makes it much clearer why this particular exception is thrown in testing environments when an invalid session attribute name type is provided. This reduces cognitive load.
+**Action:** Use custom Exceptions with descriptive names and encapsulate error messages within them to replace generic generic ones.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+    public function __construct(string $type)
+    {
+        parent::__construct(sprintf('Attribute name must be string, %s given.', $type));
+    }
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(get_debug_type($expectedAttr));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Introduced a custom `InvalidSessionAttributeException` to replace the generic `InvalidArgumentException` thrown within `SessionAssertionsTrait::seeSessionHasValues`.
🎯 Why: It provides a much clearer semantic meaning and encapsulates the specific error message `Attribute name must be string, %s given.` inside the exception class, reducing cognitive load when encountering errors in testing environments.
🛠️ Tooling: Improves type safety and ensures clear, descriptive exceptions are thrown, enhancing IDE autocompletion for expected thrown exceptions.

---
*PR created automatically by Jules for task [7163189730218141215](https://jules.google.com/task/7163189730218141215) started by @TavoNiievez*