### PR TITLE
🎨 Palette (DX): Add InvalidSessionAttributeException

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Replace generic exceptions with descriptive domain exceptions
+**Learning:** Generic \InvalidArgumentException makes it difficult to understand exactly what failed in testing code (e.g. invalid session attribute), especially without a stack trace. This increases cognitive load.
+**Action:** Always prefer creating explicitly named custom exceptions (e.g. InvalidSessionAttributeException) rather than throwing generic exceptions to clearly communicate the failure context to other developers.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Replaced the generic `\InvalidArgumentException` with a newly created custom domain exception `\Codeception\Exception\InvalidSessionAttributeException` in the `SessionAssertionsTrait`.
🎯 Why: Generic exceptions make it difficult to understand exactly what failed in testing code (e.g. invalid session attribute), especially without a stack trace. This explicitly communicates the failure context to other developers, reducing cognitive load.
🛠️ Tooling: Ran static analysis (`phpstan`) at level 8 to ensure types are correct and `phpunit` to verify no regressions were introduced. Includes a strict typing declaration `declare(strict_types=1);` in the new file.

---
*PR created automatically by Jules for task [13422512618488097349](https://jules.google.com/task/13422512618488097349) started by @TavoNiievez*