### PR TITLE
⚡ Bolt: Optimize array deduplication for internal domains

### DIFF
--- a/src/Codeception/Module/Symfony/CacheTrait.php
+++ b/src/Codeception/Module/Symfony/CacheTrait.php
@@ -8,8 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
 use function array_key_exists;
-use function array_unique;
-use function array_values;
+use function array_keys;
 use function is_string;
 
 trait CacheTrait
@@ -48,12 +47,12 @@ trait CacheTrait
 
             $hostRegex = $route->compile()->getHostRegex();
             if ($hostRegex !== null && $hostRegex !== '') {
-                $domains[] = $hostRegex;
+                $domains[$hostRegex] = true;
             }
         }
 
         /** @var list<non-empty-string> $domains */
-        $domains = array_values(array_unique($domains));
+        $domains = array_keys($domains);
         return $this->state['internalDomains'] = $domains;
     }
 


### PR DESCRIPTION
💡 **What:** Replaced the use of `array_values(array_unique($domains))` with an associative array key mapping strategy (`$domains[$hostRegex] = true` followed by `array_keys($domains)`).

🎯 **Why:** In PHP, `array_unique()` is notoriously slow, especially as datasets grow, because it uses sorting or hashing with full value comparisons (O(N log N)). By using the string as an array key, PHP leverages its highly optimized internal HashTables to guarantee uniqueness inherently with O(1) assignment per element, reducing the overall time complexity to O(N).

📊 **Impact:** Reduces CPU cycles and memory overhead by avoiding the internal sorting and duplication steps performed by `array_unique()`. While the array size might be small, every millisecond counts, and this is a standard, highly effective PHP performance pattern.

🔬 **Measurement:** Run `vendor/bin/phpunit tests/` and verify that all Codeception Symfony module tests continue to pass without any behavior change.

---
*PR created automatically by Jules for task [12593478910010667174](https://jules.google.com/task/12593478910010667174) started by @TavoNiievez*