### PR TITLE
🎨 Palette (DX): Custom domain exception for session attributes

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-07-01 - Custom Domain Exceptions for Error Clarity
+**Learning:** Using generic exceptions like `InvalidArgumentException` hides the root cause and context of errors, leading to higher cognitive load for developers trying to debug failures in testing environments.
+**Action:** Always prefer creating custom, descriptively named domain exceptions (e.g., `InvalidSessionAttributeException`) that extend the appropriate base exception. This makes it instantly clear what went wrong and where.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException {}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }

--- a/tests/_app/Message/TestMessage.php
+++ b/tests/_app/Message/TestMessage.php
@@ -8,8 +8,7 @@ final class TestMessage
 {
     public function __construct(
         private readonly string $content = '',
-    ) {
-    }
+    ) {}
 
     public function getContent(): string
     {


### PR DESCRIPTION
💡 What: Replaced the generic `InvalidArgumentException` thrown in `SessionAssertionsTrait::seeSessionHasValues` with a custom domain exception `InvalidSessionAttributeException`.
🎯 Why: Using a generic exception hides the root cause and context of errors, leading to higher cognitive load for developers trying to debug failures in testing environments. A custom domain exception makes it instantly clear what went wrong and where.
🛠️ Tooling: Improves error stack trace clarity and discoverability when debugging Codeception tests.

---
*PR created automatically by Jules for task [7613121884773866584](https://jules.google.com/task/7613121884773866584) started by @TavoNiievez*