### PR TITLE
⚡ Bolt: O(N log N) deduplication optimization

### DIFF
--- a/src/Codeception/Module/Symfony/CacheTrait.php
+++ b/src/Codeception/Module/Symfony/CacheTrait.php
@@ -8,8 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
 use function array_key_exists;
-use function array_unique;
-use function array_values;
+use function array_keys;
 use function is_string;
 
 trait CacheTrait
@@ -48,12 +47,12 @@ trait CacheTrait
 
             $hostRegex = $route->compile()->getHostRegex();
             if ($hostRegex !== null && $hostRegex !== '') {
-                $domains[] = $hostRegex;
+                $domains[$hostRegex] = true;
             }
         }
 
         /** @var list<non-empty-string> $domains */
-        $domains = array_values(array_unique($domains));
+        $domains = array_keys($domains);
         return $this->state['internalDomains'] = $domains;
     }
 


### PR DESCRIPTION
💡 What: Replaced array pushing and `array_values(array_unique())` with associative array key assignment and `array_keys()`.
🎯 Why: PHP's `array_unique` runs in O(N log N) time, whereas using array keys provides O(N) deduplication due to PHP's internal hash maps.
📊 Impact: Changes time complexity from O(N log N) to O(N) during the `getInternalDomains` router processing.
🔬 Measurement: Verify via `vendor/bin/phpunit tests/` and `vendor/bin/phpstan analyse src --level=max`.

---
*PR created automatically by Jules for task [10938166542296069858](https://jules.google.com/task/10938166542296069858) started by @TavoNiievez*