### PR TITLE
🎨 Palette (DX): Add InvalidSessionAttributeException

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Custom Exceptions for Clearer Error Context
+**Learning:** Generic exceptions like \InvalidArgumentException reduce code discoverability and increase cognitive load when reading test output or traces.
+**Action:** Always create explicitly named custom domain exceptions (e.g., `InvalidSessionAttributeException`) to clearly communicate the failure context.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+    public function __construct(string $givenType)
+    {
+        parent::__construct(sprintf('Attribute name must be string, %s given.', $givenType));
+    }
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(get_debug_type($expectedAttr));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Introduced a custom `InvalidSessionAttributeException` to replace the generic `\InvalidArgumentException` thrown when an invalid type is provided for a session attribute name in `seeSessionHasValues`.

🎯 Why: Generic exceptions reduce discoverability and increase cognitive load when reading traces. Providing an explicitly named domain exception clarifies the exact failure context.

🛠️ Tooling: Improves type strictness, avoids generic core exceptions in domain code, and fully passes PHPStan at level `max`.

---
*PR created automatically by Jules for task [10772377347003815168](https://jules.google.com/task/10772377347003815168) started by @TavoNiievez*