### PR TITLE
⚡ Bolt: Optimize `getMailerMessage` performance

### DIFF
--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -198,7 +198,9 @@ trait MailerAssertionsTrait
      */
     public function getMailerMessage(int $index = 0, ?string $transport = null): ?RawMessage
     {
-        return $this->getMailerMessages($transport)[$index] ?? null;
+        $event = $this->getMailerEvent($index, $transport);
+
+        return $event?->getMessage();
     }
 
     protected function grabLastSentRawMessage(): ?RawMessage

--- a/tests/_app/Message/TestMessage.php
+++ b/tests/_app/Message/TestMessage.php
@@ -8,8 +8,7 @@ final class TestMessage
 {
     public function __construct(
         private readonly string $content = '',
-    ) {
-    }
+    ) {}
 
     public function getContent(): string
     {


### PR DESCRIPTION
💡 What: The `getMailerMessage` method in `MailerAssertionsTrait` was updated to use `getMailerEvent($index)` to directly fetch a single event, rather than iterating over all events with `getMailerMessages()`.

🎯 Why: The previous implementation called `getMessages()`, which iterates over all mailer events to build an array of messages, only to return a single message at the requested `$index` (an O(N) operation). This caused unnecessary array allocations.

📊 Impact: Changes the complexity from O(N) to O(1) when fetching a specific mailer message by index. Memory footprint is reduced as the array of messages is not built internally.

🔬 Measurement: Verified that tests pass successfully. Tests can be run via `vendor/bin/phpunit tests/`. Code static analysis is unaffected.

---
*PR created automatically by Jules for task [12256929698817375204](https://jules.google.com/task/12256929698817375204) started by @TavoNiievez*