### PR TITLE
🎨 Palette (DX): Replace generic InvalidArgumentException with InvalidSessionAttributeException

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-07-04 - Type Safety for Exception Handling
+**Learning:** Custom domain exceptions improve DX by reducing cognitive load when catching specific errors, and preventing developers from having to parse string messages of generic exceptions.
+**Action:** Replace generic InvalidArgumentExceptions with explicitly named exceptions that subclass them.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+    public function __construct(string $type)
+    {
+        parent::__construct(sprintf('Attribute name must be string, %s given.', $type));
+    }
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(get_debug_type($expectedAttr));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Replaced a generic `InvalidArgumentException` in `SessionAssertionsTrait` with a custom domain exception `InvalidSessionAttributeException`.
🎯 Why: Throwing domain-specific exceptions reduces cognitive load and allows developers to catch specific errors rather than parsing string messages of generic exceptions.
🛠️ Tooling: Improved trace visibility by cleanly extending `InvalidArgumentException` and preserving type strictness.

---
*PR created automatically by Jules for task [11105549564948065656](https://jules.google.com/task/11105549564948065656) started by @TavoNiievez*