### PR TITLE
⚡ Bolt: Avoid O(N) allocation when fetching mailer message by index

### DIFF
--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -198,7 +198,9 @@ trait MailerAssertionsTrait
      */
     public function getMailerMessage(int $index = 0, ?string $transport = null): ?RawMessage
     {
-        return $this->getMailerMessages($transport)[$index] ?? null;
+        $event = $this->getMailerEvents($transport)[$index] ?? null;
+
+        return $event?->getMessage();
     }
 
     protected function grabLastSentRawMessage(): ?RawMessage


### PR DESCRIPTION
💡 **What:** Replaced the call to `$this->getMailerMessages($transport)[$index] ?? null;` with `$event = $this->getMailerEvents($transport)[$index] ?? null; return $event?->getMessage();` inside `getMailerMessage()`.

🎯 **Why:** `getMailerMessages()` internally loops through all collected mailer events to instantiate and return a new array of just the messages. When fetching a specific message by index, this O(N) memory allocation and iteration is entirely unnecessary. By using `getMailerEvents()`, we fetch the raw internal array of events in O(1) time and then safely extract the message.

📊 **Impact:** Reduces O(N) time and memory allocation to O(1) when retrieving a specific sent email by index. This prevents unnecessary memory usage in tests that send many emails.

🔬 **Measurement:** Run `vendor/bin/phpunit tests/` and `vendor/bin/phpstan analyse src/ --level=8` to ensure correctness.

---
*PR created automatically by Jules for task [13973092884350168255](https://jules.google.com/task/13973092884350168255) started by @TavoNiievez*