### PR TITLE
🎨 Palette (DX): Custom Exception for Session Assertions

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Improve Error Clarity with Custom Exceptions
+**Learning:** The `SessionAssertionsTrait::seeSessionHasValues` method throws a generic `InvalidArgumentException` when an invalid attribute name type is provided. Creating a custom domain exception like `InvalidSessionAttributeException` improves clarity in testing environments, clearly communicating the failure context.
+**Action:** Create a custom exception in `src/Codeception/Exception/` and use it instead of generic exceptions to reduce cognitive load.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Created `InvalidSessionAttributeException` to replace the generic `InvalidArgumentException` in `SessionAssertionsTrait`.
🎯 Why: Improves error clarity and discoverability in testing environments by providing a specific domain exception when an invalid session attribute name type is passed. This reduces cognitive load when debugging test failures.
🛠️ Tooling: Improves static analysis context for exception handling.

---
*PR created automatically by Jules for task [1401061806707842446](https://jules.google.com/task/1401061806707842446) started by @TavoNiievez*