### PR TITLE
⚡ Bolt: O(N) internal domain deduplication

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-06 - O(N) Array Deduplication Pattern
+**Learning:** In PHP, using `array_values(array_unique($array))` on arrays constructed inside a loop creates an O(N log N) operation overhead due to sorting/hashing mechanisms under the hood. For large collections, like compiling Symfony routes into domains, this is a measurable bottleneck.
+**Action:** When deduplicating strings or integers inside a loop, immediately use them as associative array keys (`$array[$value] = true;`). After the loop, use `array_keys($array)` to extract the unique values. This achieves O(N) time complexity and avoids the overhead of `array_unique`.

--- a/src/Codeception/Module/Symfony/CacheTrait.php
+++ b/src/Codeception/Module/Symfony/CacheTrait.php
@@ -8,8 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
 use function array_key_exists;
-use function array_unique;
-use function array_values;
+use function array_keys;
 use function is_string;
 
 trait CacheTrait
@@ -48,12 +47,12 @@ trait CacheTrait
 
             $hostRegex = $route->compile()->getHostRegex();
             if ($hostRegex !== null && $hostRegex !== '') {
-                $domains[] = $hostRegex;
+                $domains[$hostRegex] = true;
             }
         }
 
         /** @var list<non-empty-string> $domains */
-        $domains = array_values(array_unique($domains));
+        $domains = array_keys($domains);
         return $this->state['internalDomains'] = $domains;
     }
 


### PR DESCRIPTION
💡 **What:** Replaced `array_values(array_unique($domains))` with an associative array key assignment (`$domains[$hostRegex] = true`) followed by `array_keys($domains)` in `CacheTrait::getInternalDomains()`.

🎯 **Why:** `array_unique` is generally an O(N log N) operation, which can become a bottleneck when processing large datasets, such as compiling thousands of Symfony routes to collect internal domains. Using associative array keys naturally prevents duplicates and allows for extraction in O(N) time.

📊 **Impact:** Reduces time complexity for internal domain deduplication from O(N log N) to O(N), improving performance during test initialization/execution when many routes exist, while preserving strict output order.

🔬 **Measurement:** Verify tests run successfully (`vendor/bin/phpunit`) and no static analysis errors are introduced (`vendor/bin/phpstan analyse src/ --level=8`).

---
*PR created automatically by Jules for task [16476094496624016493](https://jules.google.com/task/16476094496624016493) started by @TavoNiievez*