### PR TITLE
🎨 Palette (DX): Add InvalidSessionAttributeException for better error clarity

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Custom Exceptions for better clarity
+**Learning:** Generic exceptions like `\InvalidArgumentException` can hide the root cause and make debugging harder.
+**Action:** Prefer creating explicitly named custom domain exceptions (e.g., `InvalidSessionAttributeException` extending `\InvalidArgumentException`) rather than throwing generic exceptions to clearly communicate the failure context and reduce cognitive load for developers.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException {}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }


### PR DESCRIPTION
💡 What: Replaced the generic `\InvalidArgumentException` with a domain-specific `InvalidSessionAttributeException` in `SessionAssertionsTrait::seeSessionHasValues`.

🎯 Why: Generic exceptions hide the root context of failures, increasing cognitive load for developers trying to debug failing tests. Using explicitly named domain exceptions clearly communicates the exact nature of the failure (i.e., that the provided session attribute type is invalid) and makes the error logs instantly understandable.

🛠️ Tooling: Improved error clarity out-of-the-box for any developers using `Codeception` test actions; PHPStan (`level max`) properly checks the new exception type; IDEs will display the correctly typed exception on hover.

---
*PR created automatically by Jules for task [11622343890263157856](https://jules.google.com/task/11622343890263157856) started by @TavoNiievez*