### PR TITLE
🎨 Palette (DX): Custom InvalidSessionAttributeException

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-07-07 - Custom Exception for Invalid Session Attributes
+**Learning:** Generic `InvalidArgumentException`s with hardcoded messages hide the specific domain context of an error and make it difficult to catch or test specific error states.
+**Action:** Created `InvalidSessionAttributeException` domain exception to encapsulate the error context when an invalid attribute type is given, reducing cognitive load and adhering to Palette's principles of clear errors.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+    public function __construct(string $givenType)
+    {
+        parent::__construct(sprintf('Attribute name must be string, %s given.', $givenType));
+    }
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
+use Codeception\Exception\InvalidSessionAttributeException;
 use InvalidArgumentException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
@@ -174,7 +175,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(get_debug_type($expectedAttr));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }

--- a/tests/_app/Message/TestMessage.php
+++ b/tests/_app/Message/TestMessage.php
@@ -8,8 +8,7 @@ final class TestMessage
 {
     public function __construct(
         private readonly string $content = '',
-    ) {
-    }
+    ) {}
 
     public function getContent(): string
     {


### PR DESCRIPTION
💡 What: Created a domain-specific `InvalidSessionAttributeException` to replace the generic `InvalidArgumentException` thrown when an invalid session attribute name type is passed.

🎯 Why: Custom domain exceptions make the codebase more discoverable and improve developer experience. It gives clear error messages and allows developers to easily capture specific types of errors without parsing generic exception messages, reducing cognitive load.

🛠️ Tooling: Improves static analysis by strictly typing the domain error, making it more predictable.

---
*PR created automatically by Jules for task [12697345624737414089](https://jules.google.com/task/12697345624737414089) started by @TavoNiievez*