### PR TITLE
🎨 Palette (DX): Use domain-specific InvalidSessionAttributeException

### DIFF
--- a/.jules/palette_dx.md
+++ b/.jules/palette_dx.md
@@ -1,0 +1,3 @@
+## 2024-07-08 - Use domain-specific exceptions over generic exceptions
+**Learning:** Generic exceptions (like \InvalidArgumentException) hide the context of the error, making it harder to debug, especially during testing environments.
+**Action:** Always prefer creating explicit domain-specific exceptions (like InvalidSessionAttributeException) for specific, identifiable errors.

--- a/src/Codeception/Exception/InvalidSessionAttributeException.php
+++ b/src/Codeception/Exception/InvalidSessionAttributeException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\Exception;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+class InvalidSessionAttributeException extends InvalidArgumentException
+{
+    public function __construct(string $type)
+    {
+        parent::__construct(sprintf('Attribute name must be string, %s given.', $type));
+    }
+}

--- a/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/SessionAssertionsTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Module\Symfony;
 
-use InvalidArgumentException;
+use Codeception\Exception\InvalidSessionAttributeException;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -174,7 +174,7 @@ trait SessionAssertionsTrait
                 continue;
             }
             if (!is_string($expectedAttr)) {
-                throw new InvalidArgumentException(sprintf('Attribute name must be string, %s given.', get_debug_type($expectedAttr)));
+                throw new InvalidSessionAttributeException(get_debug_type($expectedAttr));
             }
             $this->assertTrue($session->has($expectedAttr), "No session attribute with name '{$expectedAttr}'");
         }

--- a/tests/_app/Message/TestMessage.php
+++ b/tests/_app/Message/TestMessage.php
@@ -8,8 +8,7 @@ final class TestMessage
 {
     public function __construct(
         private readonly string $content = '',
-    ) {
-    }
+    ) {}
 
     public function getContent(): string
     {


### PR DESCRIPTION
💡 What: Created a domain-specific `InvalidSessionAttributeException` and used it in `SessionAssertionsTrait` instead of the generic `\InvalidArgumentException`.

🎯 Why: Generic exceptions hide the context of the error, increasing cognitive load when debugging tests. A specifically named exception makes it immediately clear what went wrong (an invalid type was provided for a session attribute name).

🛠️ Tooling: Improves PHPStan static analysis and IDE understandability by providing a precise, strictly typed exception constructor that only accepts the debug type string.

---
*PR created automatically by Jules for task [776109969612431430](https://jules.google.com/task/776109969612431430) started by @TavoNiievez*