### PR TITLE
⚡ Bolt: Optimize `getMailerMessage` array allocation

### DIFF
--- a/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
+++ b/src/Codeception/Module/Symfony/MailerAssertionsTrait.php
@@ -198,7 +198,7 @@ trait MailerAssertionsTrait
      */
     public function getMailerMessage(int $index = 0, ?string $transport = null): ?RawMessage
     {
-        return $this->getMailerMessages($transport)[$index] ?? null;
+        return $this->getMailerEvent($index, $transport)?->getMessage();
     }
 
     protected function grabLastSentRawMessage(): ?RawMessage


### PR DESCRIPTION
💡 **What:**
Optimized `getMailerMessage` in `MailerAssertionsTrait` to avoid an unnecessary full array allocation when retrieving a specific message.

🎯 **Why:**
Previously, `getMailerMessage($index)` called `getMailerMessages()`, which delegates to `$events->getMessages()`. The `getMessages()` method on Symfony's `MessageEvents` loops through all events and instantiates a new array on every call. For extracting just a single element, this is inefficient. We now directly ask for the event at the given index and use the nullsafe operator (`?->getMessage()`) to retrieve the message in O(1) time.

📊 **Impact:**
Avoids O(N) array duplication per call to `getMailerMessage()`. Reduces memory allocations during test suite runs making assertions slightly faster.

🔬 **Measurement:**
Run `vendor/bin/phpunit tests/` and `vendor/bin/phpstan analyse src --level=max` to verify logic behaves identically.

---
*PR created automatically by Jules for task [869209026600093737](https://jules.google.com/task/869209026600093737) started by @TavoNiievez*